### PR TITLE
Add optimized raw metrics setup path

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ curl -sSL https://raw.githubusercontent.com/Shiftius/ansible-gpu-metrics-collect
 
 To keep the current hostname unchanged, append `--skip-hostname-conf` to the `bash -s -- ...` arguments.
 
+For parent orchestration that should remain best effort, append `--tolerate-failures`.
+The scripts still log `[ERROR]` and `[WARN]` status output, but normalize failures to exit code `0`.
+
 The raw installer also accepts environment variables, which keeps secrets out of the process arguments:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -2,33 +2,30 @@
 
 ## Security Notice
 
-This playbook handles sensitive AWS credentials and database passwords. The following security measures are implemented:
+This setup handles sensitive AWS credentials and database passwords. The following security measures are implemented:
 
 ### Security Features
 - **No Debug Output**: Shell scripts run with `set +x` to prevent command echoing
-- **No-Log Tasks**: Sensitive Ansible tasks use `no_log: true` to prevent credential exposure
+- **No Secret Echoing**: Sensitive values are written to protected config files without command tracing
 - **Secure File Permissions**: Configuration files containing secrets are created with restrictive permissions (0640)
 - **Environment Variables**: Secrets are passed via environment variables, not command-line arguments where possible
-- **Ansible Configuration**: Default settings prevent display of task arguments
+- **Legacy Ansible Path Preserved**: The playbook and roles remain available for inspection or manual use, but `setup.sh` now defaults to raw shell execution
 
 ### Best Practices
 1. **Never commit secrets** to version control
-2. **Use Ansible Vault** for encrypting sensitive variables:
-   ```bash
-   ansible-vault encrypt_string 'your-secret-key' --name 'aws_timestream_secret_key'
-   ```
+2. **Prefer environment variables** over command-line arguments for secrets
 3. **Limit log verbosity** in production environments
 4. **Rotate credentials** regularly
 5. **Use IAM roles** instead of access keys when running on AWS infrastructure
 
 ### Running Securely
 
-#### Fast Path: Raw Shell Installer
-For fresh instances where startup time matters, use the flattened raw shell installer. This leaves the Ansible playbook and roles in place, but skips the Python virtualenv and Ansible install.
+#### Default: Fast Raw Shell Setup
+For fresh instances where startup time matters, use `setup.sh`. It delegates to the flattened raw shell installer, leaves the Ansible playbook and roles in place, and skips the Python virtualenv and Ansible install.
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/Shiftius/ansible-gpu-metrics-collector/main/setup-raw.sh | \
-  sudo bash -s -- aws_timestream_access_key='KEY' aws_timestream_secret_key='SECRET' aws_timestream_database='DB' environmentID='ID'
+curl -sSL https://raw.githubusercontent.com/Shiftius/ansible-gpu-metrics-collector/main/setup.sh | \
+  bash -s -- aws_timestream_access_key='KEY' aws_timestream_secret_key='SECRET' aws_timestream_database='DB' environmentID='ID'
 ```
 
 To keep the current hostname unchanged, append `--skip-hostname-conf` to the `bash -s -- ...` arguments.
@@ -41,8 +38,10 @@ export AWS_TIMESTREAM_SECRET_KEY="your-secret"
 export AWS_TIMESTREAM_DATABASE="your-db"
 export ENVIRONMENT_ID="your-environment-id"
 
-curl -sSL https://raw.githubusercontent.com/Shiftius/ansible-gpu-metrics-collector/main/setup-raw.sh | sudo -E bash
+curl -sSL https://raw.githubusercontent.com/Shiftius/ansible-gpu-metrics-collector/main/setup.sh | bash
 ```
+
+`setup-raw.sh` can still be invoked directly from a checkout or via curl when you do not need the compatibility wrapper.
 
 #### Method 1: Interactive Secure Input (RECOMMENDED)
 ```bash
@@ -59,7 +58,7 @@ export AWS_TIMESTREAM_ACCESS_KEY="your-key"
 export AWS_TIMESTREAM_SECRET_KEY="your-secret"
 export AWS_TIMESTREAM_DATABASE="your-db"
 
-# Run setup (will auto-detect env vars)
+# Run setup; it delegates to setup-raw.sh and auto-detects env vars
 ./setup.sh
 ```
 
@@ -82,15 +81,13 @@ The scripts include multiple layers of security:
 1. **Debug Mode Detection**: Scripts will exit if run with `bash -x` or `sh -x`
 2. **Trace Protection**: Detects and blocks shell tracing (`set -x`)
 3. **History Disabled**: Command history is disabled during execution
-4. **Parameter Clearing**: Positional parameters are cleared after capture
-5. **Multiple Checkpoints**: Debug mode is disabled at multiple points
+4. **Environment Credential Flow**: Environment variables are supported to avoid putting secrets in command-line arguments
+5. **Secure Permissions**: Generated secret-bearing files are written with restrictive permissions
 
 ### Debugging Safely
 If you need to debug, use targeted verbosity:
 ```bash
-# Use -vv for moderate verbosity (some tasks still hidden)
-ansible-playbook -vv playbook.yml
-
-# Use -vvv only in secure environments (may expose secrets)
-ansible-playbook -vvv playbook.yml
+# setup.sh and setup-raw.sh emit high-level [INFO], [WARN], and [ERROR] status lines.
+# Avoid bash -x or set -x because both scripts intentionally refuse traced execution.
+./setup.sh
 ```

--- a/README.md
+++ b/README.md
@@ -43,6 +43,19 @@ curl -sSL https://raw.githubusercontent.com/Shiftius/ansible-gpu-metrics-collect
 
 `setup-raw.sh` can still be invoked directly from a checkout or via curl when you do not need the compatibility wrapper.
 
+#### Benchmarking Raw vs. Ansible Setup
+Use `reset-setup.sh` between runs to remove the metrics packages, generated config, repositories, local metrics data, and metadata created by either setup path.
+
+```bash
+sudo ./reset-setup.sh --purge-benchmark-cache
+time ./setup-via-ansible.sh aws_timestream_access_key='KEY' aws_timestream_secret_key='SECRET' aws_timestream_database='DB' environmentID='ID'
+
+sudo ./reset-setup.sh --purge-benchmark-cache
+time ./setup.sh aws_timestream_access_key='KEY' aws_timestream_secret_key='SECRET' aws_timestream_database='DB' environmentID='ID'
+```
+
+For a data-preserving reset, use `sudo ./reset-setup.sh --keep-data`. The reset script does not restore the hostname.
+
 #### Method 1: Interactive Secure Input (RECOMMENDED)
 ```bash
 # Use the secure wrapper script for interactive credential input

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This setup handles sensitive AWS credentials and database passwords. The followi
 ### Running Securely
 
 #### Default: Fast Raw Shell Setup
-For fresh instances where startup time matters, use `setup.sh`. It delegates to the flattened raw shell installer, leaves the Ansible playbook and roles in place, and skips the Python virtualenv and Ansible install.
+For fresh instances where startup time matters, use `setup.sh`. It delegates to the flattened raw shell installer, leaves the Ansible playbook and roles in place, and skips Python, the Python virtualenv, and Ansible install work.
 
 ```bash
 curl -sSL https://raw.githubusercontent.com/Shiftius/ansible-gpu-metrics-collector/main/setup.sh | \

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ curl -sSL https://raw.githubusercontent.com/Shiftius/ansible-gpu-metrics-collect
 ```
 
 `setup-raw.sh` can still be invoked directly from a checkout or via curl when you do not need the compatibility wrapper.
+For compatibility with the former Ansible extra-vars flow, the raw installer accepts the existing setup values
+for `aws_timestream_*`, `environmentID`, `domain`, `host_prefix`, `skip_hostname_conf`, `influx.*`,
+`grafana.subpath`, `fleet_amd64_url`, `fleet_pkg_amd64`, `metadata_path`, and `metadata_backup`.
 
 #### Benchmarking Raw vs. Ansible Setup
 Use `reset-setup.sh` between runs to remove the metrics packages, generated config, repositories, local metrics data, and metadata created by either setup path.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ To keep the current hostname unchanged, append `--skip-hostname-conf` to the `ba
 
 The scripts include multiple layers of security:
 
-1. **Debug Mode Detection**: Scripts will exit if run with `bash -x` or `sh -x`
+1. **Debug Mode Detection**: Scripts refuse `bash -x` or `sh -x` before doing work, while preserving the default tolerated exit behavior
 2. **Trace Protection**: Detects and blocks shell tracing (`set -x`)
 3. **History Disabled**: Command history is disabled during execution
 4. **Environment Credential Flow**: Environment variables are supported to avoid putting secrets in command-line arguments

--- a/README.md
+++ b/README.md
@@ -31,8 +31,10 @@ curl -sSL https://raw.githubusercontent.com/Shiftius/ansible-gpu-metrics-collect
 
 To keep the current hostname unchanged, append `--skip-hostname-conf` to the `bash -s -- ...` arguments.
 
-For parent orchestration that should remain best effort, append `--tolerate-failures`.
-The scripts still log `[ERROR]` and `[WARN]` status output, but normalize failures to exit code `0`.
+Failure tolerance is enabled by default for parent orchestration: the scripts still log `[ERROR]` and `[WARN]`
+status output, but normalize failures to exit code `0`. Use `--strict-failures` only when you want a
+benchmark/debug run to exit nonzero on failure. `--tolerate-failures` is still accepted to explicitly request
+the default behavior.
 
 The raw installer also accepts environment variables, which keeps secrets out of the process arguments:
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This setup handles sensitive AWS credentials and database passwords. The followi
 
 #### Default: Fast Raw Shell Setup
 For fresh instances where startup time matters, use `setup.sh`. It delegates to the flattened raw shell installer, leaves the Ansible playbook and roles in place, and skips Python, the Python virtualenv, and Ansible install work.
+When run from a checkout, `setup.sh` also uses local Grafana assets instead of fetching them over HTTP and installs the metrics packages plus the Fleet deb in a single apt transaction.
 
 ```bash
 curl -sSL https://raw.githubusercontent.com/Shiftius/ansible-gpu-metrics-collector/main/setup.sh | \

--- a/README.md
+++ b/README.md
@@ -23,6 +23,27 @@ This playbook handles sensitive AWS credentials and database passwords. The foll
 
 ### Running Securely
 
+#### Fast Path: Raw Shell Installer
+For fresh instances where startup time matters, use the flattened raw shell installer. This leaves the Ansible playbook and roles in place, but skips the Python virtualenv and Ansible install.
+
+```bash
+curl -sSL https://raw.githubusercontent.com/Shiftius/ansible-gpu-metrics-collector/main/setup-raw.sh | \
+  sudo bash -s -- aws_timestream_access_key='KEY' aws_timestream_secret_key='SECRET' aws_timestream_database='DB' environmentID='ID'
+```
+
+To keep the current hostname unchanged, append `--skip-hostname-conf` to the `bash -s -- ...` arguments.
+
+The raw installer also accepts environment variables, which keeps secrets out of the process arguments:
+
+```bash
+export AWS_TIMESTREAM_ACCESS_KEY="your-key"
+export AWS_TIMESTREAM_SECRET_KEY="your-secret"
+export AWS_TIMESTREAM_DATABASE="your-db"
+export ENVIRONMENT_ID="your-environment-id"
+
+curl -sSL https://raw.githubusercontent.com/Shiftius/ansible-gpu-metrics-collector/main/setup-raw.sh | sudo -E bash
+```
+
 #### Method 1: Interactive Secure Input (RECOMMENDED)
 ```bash
 # Use the secure wrapper script for interactive credential input

--- a/reset-setup.sh
+++ b/reset-setup.sh
@@ -6,6 +6,7 @@ set +x
 PURGE_DATA=true
 PURGE_BENCHMARK_CACHE=false
 REFRESH_APT=false
+TOLERATE_FAILURES=false
 FLEET_PACKAGE_NAME="${FLEET_PACKAGE_NAME:-fleet-osquery}"
 FLEET_PKG_AMD64="${FLEET_PKG_AMD64:-fleet-1.0.0_amd64.deb}"
 METADATA_PATH="${METADATA_PATH:-/etc/brev/metadata.json}"
@@ -35,6 +36,7 @@ Options:
   --keep-data              Keep InfluxDB/Grafana/Telegraf data and /etc/brev metadata.
   --purge-benchmark-cache  Also remove /tmp/ansible_env, /tmp/mc, and /var/log/ansible.
   --refresh-apt            Run apt-get update after removing repository files.
+  --tolerate-failures      Log failures but exit 0 for parent orchestration.
   --fleet-package NAME     Fleet Debian package name to purge. Default: fleet-osquery.
   --metadata-path PATH     Metadata JSON path to remove. Default: /etc/brev/metadata.json.
   -h, --help               Show this help.
@@ -46,8 +48,42 @@ EOF
 require_root() {
     if [[ "$(id -u)" -ne 0 ]]; then
         echo_error "Run this script as root or with sudo."
-        exit 1
+        return 1
     fi
+}
+
+exit_with_status() {
+    local status="$1"
+
+    if [[ "$status" -ne 0 && "$TOLERATE_FAILURES" == true ]]; then
+        echo_warn "reset-setup.sh failed with exit code ${status}; --tolerate-failures enabled, exiting 0."
+        exit 0
+    fi
+
+    exit "$status"
+}
+
+parse_tolerance_flag() {
+    local arg
+
+    for arg in "$@"; do
+        if [[ "$arg" == "--tolerate-failures" ]]; then
+            TOLERATE_FAILURES=true
+        fi
+    done
+}
+
+run_main() {
+    local status
+
+    set +e
+    (
+        set -Eeuo pipefail
+        main "$@"
+    )
+    status="$?"
+
+    exit_with_status "$status"
 }
 
 parse_args() {
@@ -65,10 +101,14 @@ parse_args() {
                 REFRESH_APT=true
                 shift
                 ;;
+            --tolerate-failures)
+                TOLERATE_FAILURES=true
+                shift
+                ;;
             --fleet-package)
                 if [[ $# -lt 2 ]]; then
                     echo_error "--fleet-package requires a package name."
-                    exit 1
+                    return 1
                 fi
                 FLEET_PACKAGE_NAME="$2"
                 shift 2
@@ -76,7 +116,7 @@ parse_args() {
             --metadata-path)
                 if [[ $# -lt 2 ]]; then
                     echo_error "--metadata-path requires a path."
-                    exit 1
+                    return 1
                 fi
                 METADATA_PATH="$2"
                 shift 2
@@ -88,7 +128,7 @@ parse_args() {
             *)
                 echo_error "Unknown option: $1"
                 usage
-                exit 1
+                return 1
                 ;;
         esac
     done
@@ -124,7 +164,7 @@ wait_for_apt_lock() {
 
         if (( elapsed >= lock_wait_time )); then
             echo_error "Timeout waiting for apt/dpkg locks to be released."
-            exit 1
+            return 1
         fi
 
         sleep "$interval"
@@ -280,7 +320,7 @@ main() {
 
     if ! command -v apt-get >/dev/null 2>&1; then
         echo_error "This reset script currently supports apt-based Debian/Ubuntu instances."
-        exit 1
+        return 1
     fi
 
     stop_disable_service telegraf
@@ -297,4 +337,5 @@ main() {
     echo_info "Reset completed. Hostname was not changed."
 }
 
-main "$@"
+parse_tolerance_flag "$@"
+run_main "$@"

--- a/reset-setup.sh
+++ b/reset-setup.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+set +x
+
+PURGE_DATA=true
+PURGE_BENCHMARK_CACHE=false
+FLEET_PACKAGE_NAME="${FLEET_PACKAGE_NAME:-fleet}"
+FLEET_PKG_AMD64="${FLEET_PKG_AMD64:-fleet-1.0.0_amd64.deb}"
+METADATA_PATH="${METADATA_PATH:-/etc/brev/metadata.json}"
+
+echo_info() {
+    printf '\033[1;34m[INFO]\033[0m %s\n' "$*"
+}
+
+echo_warn() {
+    printf '\033[1;33m[WARN]\033[0m %s\n' "$*" >&2
+}
+
+echo_error() {
+    printf '\033[1;31m[ERROR]\033[0m %s\n' "$*" >&2
+}
+
+usage() {
+    cat <<'EOF'
+Usage: ./reset-setup.sh [options]
+
+Removes the metrics collector installation so setup.sh and setup-via-ansible.sh
+can be benchmarked from a cleaner state.
+
+Options:
+  --keep-data              Keep InfluxDB/Grafana/Telegraf data and /etc/brev metadata.
+  --purge-benchmark-cache  Also remove /tmp/ansible_env, /tmp/mc, and /var/log/ansible.
+  --fleet-package NAME     Fleet Debian package name to purge. Default: fleet.
+  --metadata-path PATH     Metadata JSON path to remove. Default: /etc/brev/metadata.json.
+  -h, --help               Show this help.
+
+The script does not restore the system hostname.
+EOF
+}
+
+require_root() {
+    if [[ "$(id -u)" -ne 0 ]]; then
+        echo_error "Run this script as root or with sudo."
+        exit 1
+    fi
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --keep-data)
+                PURGE_DATA=false
+                shift
+                ;;
+            --purge-benchmark-cache)
+                PURGE_BENCHMARK_CACHE=true
+                shift
+                ;;
+            --fleet-package)
+                if [[ $# -lt 2 ]]; then
+                    echo_error "--fleet-package requires a package name."
+                    exit 1
+                fi
+                FLEET_PACKAGE_NAME="$2"
+                shift 2
+                ;;
+            --metadata-path)
+                if [[ $# -lt 2 ]]; then
+                    echo_error "--metadata-path requires a path."
+                    exit 1
+                fi
+                METADATA_PATH="$2"
+                shift 2
+                ;;
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            *)
+                echo_error "Unknown option: $1"
+                usage
+                exit 1
+                ;;
+        esac
+    done
+}
+
+wait_for_apt_lock() {
+    local elapsed=0
+    local interval=5
+    local lock_wait_time=360
+    local locks=(
+        /var/lib/dpkg/lock
+        /var/lib/dpkg/lock-frontend
+        /var/lib/apt/lists/lock
+        /var/cache/apt/archives/lock
+    )
+
+    echo_info "Waiting for apt/dpkg locks to be released..."
+    while true; do
+        local busy=false
+        local lock_file
+
+        for lock_file in "${locks[@]}"; do
+            if [[ -e "$lock_file" ]] && fuser "$lock_file" >/dev/null 2>&1; then
+                busy=true
+                break
+            fi
+        done
+
+        if [[ "$busy" == false ]]; then
+            echo_info "Apt locks are free."
+            return
+        fi
+
+        if (( elapsed >= lock_wait_time )); then
+            echo_error "Timeout waiting for apt/dpkg locks to be released."
+            exit 1
+        fi
+
+        sleep "$interval"
+        elapsed=$((elapsed + interval))
+    done
+}
+
+stop_disable_service() {
+    local service="$1"
+
+    if systemctl list-unit-files "$service" >/dev/null 2>&1 || systemctl status "$service" >/dev/null 2>&1; then
+        echo_info "Stopping and disabling ${service}..."
+        systemctl disable --now "$service" >/dev/null 2>&1 || true
+    fi
+}
+
+package_installed() {
+    dpkg-query -W -f='${Status}' "$1" 2>/dev/null | grep -q "install ok installed"
+}
+
+purge_packages() {
+    local packages=("$@")
+    local installed=()
+    local package
+
+    for package in "${packages[@]}"; do
+        if package_installed "$package"; then
+            installed+=("$package")
+        fi
+    done
+
+    if [[ ${#installed[@]} -eq 0 ]]; then
+        echo_info "No benchmark packages are currently installed."
+        return
+    fi
+
+    echo_info "Purging packages: ${installed[*]}"
+    wait_for_apt_lock
+    DEBIAN_FRONTEND=noninteractive apt-get purge -y "${installed[@]}"
+    wait_for_apt_lock
+    DEBIAN_FRONTEND=noninteractive apt-get autoremove -y
+}
+
+remove_paths() {
+    local path
+
+    for path in "$@"; do
+        if [[ -e "$path" || -L "$path" ]]; then
+            echo_info "Removing ${path}"
+            rm -rf "$path"
+        fi
+    done
+}
+
+remove_repo_state() {
+    echo_info "Removing metrics apt repository state..."
+    remove_paths \
+        /etc/apt/sources.list.d/influxdata.list \
+        /etc/apt/sources.list.d/influxdb.list \
+        /etc/apt/sources.list.d/grafana.list \
+        /etc/apt/keyrings/influxdata-apt-keyring.asc \
+        /etc/apt/keyrings/influxdata.gpg \
+        /etc/apt/keyrings/grafana.asc \
+        /etc/apt/keyrings/grafana.key \
+        /usr/share/keyrings/grafana.key \
+        /usr/share/keyrings/grafana.asc \
+        /etc/apt/trusted.gpg.d/influxdata-archive_compat.gpg
+}
+
+remove_config_and_data() {
+    echo_info "Removing generated metrics configuration..."
+    remove_paths \
+        /etc/default/telegraf \
+        /etc/telegraf \
+        /etc/grafana \
+        /etc/influxdb \
+        /etc/influxdb2 \
+        "/opt/${FLEET_PKG_AMD64}"
+
+    if [[ "$PURGE_DATA" == true ]]; then
+        echo_info "Removing generated metrics data and metadata..."
+        remove_paths \
+            /var/lib/grafana \
+            /var/log/grafana \
+            /var/lib/influxdb \
+            /var/lib/influxdb2 \
+            /var/log/influxdb \
+            /var/log/influxdb2 \
+            /var/log/telegraf \
+            "$METADATA_PATH" \
+            "${METADATA_PATH}.bak" \
+            "${METADATA_PATH}.invalid"
+    else
+        echo_info "Keeping metrics data and metadata."
+    fi
+}
+
+remove_benchmark_cache() {
+    if [[ "$PURGE_BENCHMARK_CACHE" == false ]]; then
+        return
+    fi
+
+    echo_info "Removing benchmark cache from the Ansible bootstrap path..."
+    remove_paths /tmp/ansible_env /tmp/mc /var/log/ansible
+}
+
+refresh_apt() {
+    if command -v apt-get >/dev/null 2>&1; then
+        echo_info "Refreshing apt package lists..."
+        wait_for_apt_lock
+        DEBIAN_FRONTEND=noninteractive apt-get update || echo_warn "apt-get update failed after repository cleanup."
+    fi
+}
+
+main() {
+    parse_args "$@"
+    require_root
+
+    if ! command -v apt-get >/dev/null 2>&1; then
+        echo_error "This reset script currently supports apt-based Debian/Ubuntu instances."
+        exit 1
+    fi
+
+    stop_disable_service telegraf
+    stop_disable_service grafana-server
+    stop_disable_service influxdb
+
+    purge_packages grafana telegraf influxdb2 influxdb2-cli "$FLEET_PACKAGE_NAME"
+    remove_repo_state
+    remove_config_and_data
+    remove_benchmark_cache
+    refresh_apt
+
+    echo_info "Reset completed. Hostname was not changed."
+}
+
+main "$@"

--- a/reset-setup.sh
+++ b/reset-setup.sh
@@ -6,7 +6,9 @@ set +x
 PURGE_DATA=true
 PURGE_BENCHMARK_CACHE=false
 REFRESH_APT=false
-TOLERATE_FAILURES=false
+# Failures are tolerated by default so parent benchmark/orchestration scripts do
+# not fail closed if cleanup encounters an issue.
+TOLERATE_FAILURES=true
 FLEET_PACKAGE_NAME="${FLEET_PACKAGE_NAME:-fleet-osquery}"
 FLEET_PKG_AMD64="${FLEET_PKG_AMD64:-fleet-1.0.0_amd64.deb}"
 METADATA_PATH="${METADATA_PATH:-/etc/brev/metadata.json}"
@@ -36,7 +38,8 @@ Options:
   --keep-data              Keep InfluxDB/Grafana/Telegraf data and /etc/brev metadata.
   --purge-benchmark-cache  Also remove /tmp/ansible_env, /tmp/mc, and /var/log/ansible.
   --refresh-apt            Run apt-get update after removing repository files.
-  --tolerate-failures      Log failures but exit 0 for parent orchestration.
+  --tolerate-failures      Log failures but exit 0 for parent orchestration. This is the default.
+  --strict-failures        Exit nonzero on failures.
   --fleet-package NAME     Fleet Debian package name to purge. Default: fleet-osquery.
   --metadata-path PATH     Metadata JSON path to remove. Default: /etc/brev/metadata.json.
   -h, --help               Show this help.
@@ -56,7 +59,7 @@ exit_with_status() {
     local status="$1"
 
     if [[ "$status" -ne 0 && "$TOLERATE_FAILURES" == true ]]; then
-        echo_warn "reset-setup.sh failed with exit code ${status}; --tolerate-failures enabled, exiting 0."
+        echo_warn "reset-setup.sh failed with exit code ${status}; failure tolerance enabled, exiting 0."
         exit 0
     fi
 
@@ -67,9 +70,14 @@ parse_tolerance_flag() {
     local arg
 
     for arg in "$@"; do
-        if [[ "$arg" == "--tolerate-failures" ]]; then
-            TOLERATE_FAILURES=true
-        fi
+        case "$arg" in
+            --tolerate-failures)
+                TOLERATE_FAILURES=true
+                ;;
+            --strict-failures)
+                TOLERATE_FAILURES=false
+                ;;
+        esac
     done
 }
 
@@ -103,6 +111,10 @@ parse_args() {
                 ;;
             --tolerate-failures)
                 TOLERATE_FAILURES=true
+                shift
+                ;;
+            --strict-failures)
+                TOLERATE_FAILURES=false
                 shift
                 ;;
             --fleet-package)

--- a/reset-setup.sh
+++ b/reset-setup.sh
@@ -6,7 +6,7 @@ set +x
 PURGE_DATA=true
 PURGE_BENCHMARK_CACHE=false
 REFRESH_APT=false
-FLEET_PACKAGE_NAME="${FLEET_PACKAGE_NAME:-fleet}"
+FLEET_PACKAGE_NAME="${FLEET_PACKAGE_NAME:-fleet-osquery}"
 FLEET_PKG_AMD64="${FLEET_PKG_AMD64:-fleet-1.0.0_amd64.deb}"
 METADATA_PATH="${METADATA_PATH:-/etc/brev/metadata.json}"
 TEMP_INFLUXDB_UNIT_CREATED=false
@@ -35,7 +35,7 @@ Options:
   --keep-data              Keep InfluxDB/Grafana/Telegraf data and /etc/brev metadata.
   --purge-benchmark-cache  Also remove /tmp/ansible_env, /tmp/mc, and /var/log/ansible.
   --refresh-apt            Run apt-get update after removing repository files.
-  --fleet-package NAME     Fleet Debian package name to purge. Default: fleet.
+  --fleet-package NAME     Fleet Debian package name to purge. Default: fleet-osquery.
   --metadata-path PATH     Metadata JSON path to remove. Default: /etc/brev/metadata.json.
   -h, --help               Show this help.
 
@@ -287,7 +287,7 @@ main() {
     stop_disable_service influxdb
 
     ensure_influxdb_unit_for_package_removal
-    purge_packages grafana telegraf influxdb2 influxdb2-cli "$FLEET_PACKAGE_NAME"
+    purge_packages grafana telegraf influxdb2 influxdb2-cli "$FLEET_PACKAGE_NAME" fleet
     remove_repo_state
     remove_config_and_data
     remove_benchmark_cache

--- a/reset-setup.sh
+++ b/reset-setup.sh
@@ -139,14 +139,6 @@ package_present() {
     dpkg-query -W "$1" >/dev/null 2>&1
 }
 
-unit_file_exists() {
-    local service="$1"
-
-    [[ -e "/etc/systemd/system/${service}" ]] \
-        || [[ -e "/lib/systemd/system/${service}" ]] \
-        || [[ -e "/usr/lib/systemd/system/${service}" ]]
-}
-
 cleanup_temp_units() {
     if [[ "$TEMP_INFLUXDB_UNIT_CREATED" == true ]]; then
         rm -f "$TEMP_INFLUXDB_UNIT_PATH"
@@ -155,7 +147,7 @@ cleanup_temp_units() {
 }
 
 ensure_influxdb_unit_for_package_removal() {
-    if ! package_present influxdb2 || unit_file_exists influxdb.service; then
+    if ! package_present influxdb2; then
         return
     fi
 

--- a/reset-setup.sh
+++ b/reset-setup.sh
@@ -5,6 +5,7 @@ set +x
 
 PURGE_DATA=true
 PURGE_BENCHMARK_CACHE=false
+REFRESH_APT=false
 FLEET_PACKAGE_NAME="${FLEET_PACKAGE_NAME:-fleet}"
 FLEET_PKG_AMD64="${FLEET_PKG_AMD64:-fleet-1.0.0_amd64.deb}"
 METADATA_PATH="${METADATA_PATH:-/etc/brev/metadata.json}"
@@ -33,6 +34,7 @@ can be benchmarked from a cleaner state.
 Options:
   --keep-data              Keep InfluxDB/Grafana/Telegraf data and /etc/brev metadata.
   --purge-benchmark-cache  Also remove /tmp/ansible_env, /tmp/mc, and /var/log/ansible.
+  --refresh-apt            Run apt-get update after removing repository files.
   --fleet-package NAME     Fleet Debian package name to purge. Default: fleet.
   --metadata-path PATH     Metadata JSON path to remove. Default: /etc/brev/metadata.json.
   -h, --help               Show this help.
@@ -57,6 +59,10 @@ parse_args() {
                 ;;
             --purge-benchmark-cache)
                 PURGE_BENCHMARK_CACHE=true
+                shift
+                ;;
+            --refresh-apt)
+                REFRESH_APT=true
                 shift
                 ;;
             --fleet-package)
@@ -238,6 +244,8 @@ remove_config_and_data() {
             /var/log/influxdb \
             /var/log/influxdb2 \
             /var/log/telegraf \
+            /root/.influxdbv2 \
+            /home/ubuntu/.influxdbv2 \
             "$METADATA_PATH" \
             "${METADATA_PATH}.bak" \
             "${METADATA_PATH}.invalid"
@@ -256,7 +264,7 @@ remove_benchmark_cache() {
 }
 
 refresh_apt() {
-    if command -v apt-get >/dev/null 2>&1; then
+    if [[ "$REFRESH_APT" == true ]] && command -v apt-get >/dev/null 2>&1; then
         echo_info "Refreshing apt package lists..."
         wait_for_apt_lock
         DEBIAN_FRONTEND=noninteractive apt-get update || echo_warn "apt-get update failed after repository cleanup."

--- a/reset-setup.sh
+++ b/reset-setup.sh
@@ -8,6 +8,8 @@ PURGE_BENCHMARK_CACHE=false
 FLEET_PACKAGE_NAME="${FLEET_PACKAGE_NAME:-fleet}"
 FLEET_PKG_AMD64="${FLEET_PKG_AMD64:-fleet-1.0.0_amd64.deb}"
 METADATA_PATH="${METADATA_PATH:-/etc/brev/metadata.json}"
+TEMP_INFLUXDB_UNIT_CREATED=false
+TEMP_INFLUXDB_UNIT_PATH="/etc/systemd/system/influxdb.service"
 
 echo_info() {
     printf '\033[1;34m[INFO]\033[0m %s\n' "$*"
@@ -133,8 +135,46 @@ stop_disable_service() {
     fi
 }
 
-package_installed() {
-    dpkg-query -W -f='${Status}' "$1" 2>/dev/null | grep -q "install ok installed"
+package_present() {
+    dpkg-query -W "$1" >/dev/null 2>&1
+}
+
+unit_file_exists() {
+    local service="$1"
+
+    [[ -e "/etc/systemd/system/${service}" ]] \
+        || [[ -e "/lib/systemd/system/${service}" ]] \
+        || [[ -e "/usr/lib/systemd/system/${service}" ]]
+}
+
+cleanup_temp_units() {
+    if [[ "$TEMP_INFLUXDB_UNIT_CREATED" == true ]]; then
+        rm -f "$TEMP_INFLUXDB_UNIT_PATH"
+        systemctl daemon-reload >/dev/null 2>&1 || true
+    fi
+}
+
+ensure_influxdb_unit_for_package_removal() {
+    if ! package_present influxdb2 || unit_file_exists influxdb.service; then
+        return
+    fi
+
+    echo_info "Creating temporary influxdb.service so the influxdb2 package removal script can complete..."
+    cat > "$TEMP_INFLUXDB_UNIT_PATH" <<'EOF'
+[Unit]
+Description=Temporary InfluxDB service stub for package removal
+
+[Service]
+Type=oneshot
+ExecStart=/bin/true
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    chmod 0644 "$TEMP_INFLUXDB_UNIT_PATH"
+    systemctl daemon-reload
+    TEMP_INFLUXDB_UNIT_CREATED=true
 }
 
 purge_packages() {
@@ -143,7 +183,7 @@ purge_packages() {
     local package
 
     for package in "${packages[@]}"; do
-        if package_installed "$package"; then
+        if package_present "$package"; then
             installed+=("$package")
         fi
     done
@@ -232,6 +272,8 @@ refresh_apt() {
 }
 
 main() {
+    trap cleanup_temp_units EXIT
+
     parse_args "$@"
     require_root
 
@@ -244,6 +286,7 @@ main() {
     stop_disable_service grafana-server
     stop_disable_service influxdb
 
+    ensure_influxdb_unit_for_package_removal
     purge_packages grafana telegraf influxdb2 influxdb2-cli "$FLEET_PACKAGE_NAME"
     remove_repo_state
     remove_config_and_data

--- a/reset-setup.sh
+++ b/reset-setup.sh
@@ -261,6 +261,7 @@ remove_benchmark_cache() {
 
     echo_info "Removing benchmark cache from the Ansible bootstrap path..."
     remove_paths /tmp/ansible_env /tmp/mc /var/log/ansible
+    chmod 1777 /tmp
 }
 
 refresh_apt() {

--- a/reset-setup.sh
+++ b/reset-setup.sh
@@ -193,9 +193,9 @@ purge_packages() {
 
     echo_info "Purging packages: ${installed[*]}"
     wait_for_apt_lock
-    DEBIAN_FRONTEND=noninteractive apt-get purge -y "${installed[@]}"
+    NEEDRESTART_SUSPEND=1 DEBIAN_FRONTEND=noninteractive apt-get purge -y "${installed[@]}"
     wait_for_apt_lock
-    DEBIAN_FRONTEND=noninteractive apt-get autoremove -y
+    NEEDRESTART_SUSPEND=1 DEBIAN_FRONTEND=noninteractive apt-get autoremove -y
 }
 
 remove_paths() {
@@ -267,7 +267,7 @@ refresh_apt() {
     if [[ "$REFRESH_APT" == true ]] && command -v apt-get >/dev/null 2>&1; then
         echo_info "Refreshing apt package lists..."
         wait_for_apt_lock
-        DEBIAN_FRONTEND=noninteractive apt-get update || echo_warn "apt-get update failed after repository cleanup."
+        NEEDRESTART_SUSPEND=1 DEBIAN_FRONTEND=noninteractive apt-get update || echo_warn "apt-get update failed after repository cleanup."
     fi
 }
 

--- a/setup-raw.sh
+++ b/setup-raw.sh
@@ -111,6 +111,63 @@ download_file() {
     chmod "$mode" "$dest"
 }
 
+escape_sed_replacement() {
+    printf '%s' "$1" | sed 's/[&@\\]/\\&/g'
+}
+
+run_capture() {
+    sh -c "$1" 2>/dev/null || true
+}
+
+first_line() {
+    run_capture "$1" | head -n 1 | tr -d '\n'
+}
+
+int_value() {
+    local value="${1:-0}"
+
+    if [[ "$value" =~ ^[0-9]+$ ]]; then
+        printf '%s' "$value"
+    else
+        printf '0'
+    fi
+}
+
+sysfs_first() {
+    local default="$1"
+    shift
+    local path value
+
+    for path in "$@"; do
+        if [[ -r "$path" ]]; then
+            value="$(tr -d '\n' < "$path")"
+            if [[ -n "$value" ]]; then
+                printf '%s' "$value"
+                return
+            fi
+        fi
+    done
+
+    printf '%s' "$default"
+}
+
+nvidia_query() {
+    local field="$1"
+    local first_only="${2:-false}"
+    local output
+
+    output="$(run_capture "nvidia-smi --query-gpu=${field} --format=csv,noheader")"
+    if [[ -z "$output" ]]; then
+        return
+    fi
+
+    if [[ "$first_only" == true ]]; then
+        printf '%s' "$output" | awk 'NF {print; exit}' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//'
+    else
+        printf '%s' "$output" | awk 'NF {gsub(/^[[:space:]]+|[[:space:]]+$/, ""); printf "%s%s", sep, $0; sep=","}'
+    fi
+}
+
 parse_args() {
     local arg value
 
@@ -234,7 +291,7 @@ install_base_packages() {
 
     echo_info "Installing base packages..."
     apt_update
-    apt_install ca-certificates curl dmidecode gnupg jq lshw pciutils python3 wget
+    apt_install ca-certificates curl dmidecode gnupg jq lshw pciutils wget
 }
 
 configure_repositories() {
@@ -410,26 +467,17 @@ EOF
 render_grafana_ini() {
     local template_file="$1"
     local output_file="$2"
+    local hostid domain subpath
 
-    python3 - "$template_file" "$output_file" <<'PY'
-import os
-import sys
+    hostid="$(escape_sed_replacement "$HOSTID")"
+    domain="$(escape_sed_replacement "$DOMAIN_VALUE")"
+    subpath="$(escape_sed_replacement "$GRAFANA_SUBPATH")"
 
-template_path, output_path = sys.argv[1], sys.argv[2]
-with open(template_path, "r", encoding="utf-8") as handle:
-    content = handle.read()
-
-replacements = {
-    "{{ hostid }}": os.environ["HOSTID"],
-    "{{ domain }}": os.environ["DOMAIN_VALUE"],
-    "{{ grafana.subpath }}": os.environ["GRAFANA_SUBPATH"],
-}
-for old, new in replacements.items():
-    content = content.replace(old, new)
-
-with open(output_path, "w", encoding="utf-8") as handle:
-    handle.write(content)
-PY
+    sed \
+        -e "s@{{ hostid }}@${hostid}@g" \
+        -e "s@{{ domain }}@${domain}@g" \
+        -e "s@{{ grafana.subpath }}@${subpath}@g" \
+        "$template_file" > "$output_file"
 }
 
 configure_grafana() {
@@ -489,211 +537,242 @@ EOF
     systemctl_enable_restart grafana-server
 }
 
-collect_hardware_metadata() {
-    echo_info "Collecting hardware metadata..."
+network_interfaces_json() {
+    local interfaces='[]'
+    local path
 
-    METADATA_PATH="$METADATA_PATH" python3 <<'PY'
-import glob
-import json
-import os
-import platform
-import shutil
-import socket
-import subprocess
-from pathlib import Path
+    for path in /sys/class/net/*; do
+        [[ -e "$path" ]] || continue
+        interfaces="$(jq -c --arg iface "$(basename "$path")" '. + [$iface]' <<< "$interfaces")"
+    done
 
-metadata_path = Path(os.environ.get("METADATA_PATH", "/etc/brev/metadata.json"))
-
-def run(command):
-    try:
-        return subprocess.check_output(command, shell=True, stderr=subprocess.DEVNULL, text=True).strip()
-    except Exception:
-        return ""
-
-def run_lines(command):
-    output = run(command)
-    return [line.strip() for line in output.splitlines() if line.strip()]
-
-def first_line(command):
-    lines = run_lines(command)
-    return lines[0] if lines else ""
-
-def int_value(value):
-    try:
-        return int(str(value).strip())
-    except Exception:
-        return 0
-
-def nvidia_query(field, join_lines=True):
-    output = run(f"nvidia-smi --query-gpu={field} --format=csv,noheader 2>/dev/null")
-    if not output:
-        return ""
-    lines = [line.strip() for line in output.splitlines() if line.strip()]
-    if not join_lines:
-        return lines[0] if lines else ""
-    return ",".join(lines)
-
-def cpu_model():
-    model = first_line("awk -F': ' '/model name/ {print $2; exit}' /proc/cpuinfo")
-    return model or platform.processor() or "Unknown"
-
-def meminfo_mb(key):
-    raw = first_line(f"awk '/^{key}:/ {{print $2; exit}}' /proc/meminfo")
-    return int_value(raw) // 1024
-
-def processor_count():
-    return int_value(run("grep -c '^physical id' /proc/cpuinfo")) or 1
-
-def processor_cores():
-    return int_value(first_line("awk -F': ' '/cpu cores/ {print $2; exit}' /proc/cpuinfo"))
-
-def processor_vcpus():
-    return os.cpu_count() or 0
-
-def threads_per_core():
-    cores = processor_cores()
-    vcpus = processor_vcpus()
-    return int(vcpus / cores) if cores and vcpus else 0
-
-def sysfs_first(paths, default="unknown"):
-    for path in paths:
-        try:
-            value = Path(path).read_text(encoding="utf-8", errors="ignore").strip()
-            if value:
-                return value
-        except Exception:
-            pass
-    return default
-
-def network_interfaces():
-    return sorted(Path(path).name for path in glob.glob("/sys/class/net/*"))
-
-def storage_devices():
-    devices = {}
-    for path in sorted(glob.glob("/sys/block/*")):
-        name = Path(path).name
-        if name.startswith(("loop", "ram")):
-            continue
-        size = int_value(sysfs_first([f"{path}/size"], "0"))
-        model = sysfs_first([f"{path}/device/model"], "")
-        rotational = sysfs_first([f"{path}/queue/rotational"], "")
-        devices[name] = {
-            "model": model,
-            "sectors": size,
-            "size_bytes": size * 512,
-            "rotational": rotational,
-        }
-    return devices
-
-lspci_gpu_count = int_value(run("lspci 2>/dev/null | grep -icE 'VGA|3D controller.*NVIDIA|Display.*NVIDIA'"))
-nvidia_gpu_count = int_value(nvidia_query("count", join_lines=False))
-amd_gpu_count = int_value(run("lspci 2>/dev/null | grep -icE 'VGA.*AMD|3D.*AMD|Display.*AMD'"))
-intel_gpu_count = int_value(run("lspci 2>/dev/null | grep -icE 'VGA.*Intel|Display.*Intel.*Graphics'"))
-total_gpu_count = (nvidia_gpu_count if nvidia_gpu_count > 0 else lspci_gpu_count) + amd_gpu_count + intel_gpu_count
-
-cuda_toolkit_version = run("nvcc --version 2>/dev/null | grep 'release' | sed 's/.*release \\([0-9.]*\\).*/\\1/' | tr -d '\\n'")
-cuda_runtime_version = run("ldconfig -p 2>/dev/null | grep -oP 'libcudart\\.so\\.\\K[0-9.]+' | head -1 | tr -d '\\n'")
-nvidia_driver_version = nvidia_query("driver_version", join_lines=False)
-nvidia_gpu_names = nvidia_query("name")
-nvidia_gpu_memory = nvidia_query("memory.total")
-nvidia_gpu_compute_cap = nvidia_query("compute_cap")
-
-hardware_metadata = {
-    "hardware_summary": {
-        "cpu_model": cpu_model(),
-        "total_cpus": processor_count(),
-        "total_cores": processor_cores(),
-        "total_vcpus": processor_vcpus(),
-        "total_memory_mb": meminfo_mb("MemTotal"),
-        "total_gpus": total_gpu_count,
-        "gpu_models": nvidia_gpu_names,
-        "nvidia_driver_version": nvidia_driver_version,
-        "cuda_toolkit_version": cuda_toolkit_version,
-        "cuda_runtime_version": cuda_runtime_version,
-        "gpu_memory_total_mb": nvidia_gpu_memory,
-        "gpu_compute_capabilities": nvidia_gpu_compute_cap,
-        "system_vendor": sysfs_first(["/sys/class/dmi/id/sys_vendor"], "Unknown"),
-        "system_model": sysfs_first(["/sys/class/dmi/id/product_name"], "Unknown"),
-    },
-    "hardware": {
-        "cpu": {
-            "architecture": platform.machine() or "unknown",
-            "processor_count": processor_count(),
-            "processor_cores": processor_cores(),
-            "processor_threads_per_core": threads_per_core(),
-            "processor_vcpus": processor_vcpus(),
-            "model_name": cpu_model(),
-        },
-        "memory": {
-            "total_mb": meminfo_mb("MemTotal"),
-            "free_mb": meminfo_mb("MemFree"),
-            "swap_total_mb": meminfo_mb("SwapTotal"),
-            "swap_free_mb": meminfo_mb("SwapFree"),
-        },
-        "motherboard": {
-            "manufacturer": sysfs_first(["/sys/class/dmi/id/board_vendor", "/sys/class/dmi/id/sys_vendor"], "unknown"),
-            "product_name": sysfs_first(["/sys/class/dmi/id/board_name", "/sys/class/dmi/id/product_name"], "unknown"),
-            "product_version": sysfs_first(["/sys/class/dmi/id/board_version", "/sys/class/dmi/id/product_version"], "unknown"),
-        },
-        "bios": {
-            "vendor": sysfs_first(["/sys/class/dmi/id/bios_version"], "unknown"),
-            "version": sysfs_first(["/sys/class/dmi/id/bios_version"], "unknown"),
-            "date": sysfs_first(["/sys/class/dmi/id/bios_date"], "unknown"),
-        },
-        "system": {
-            "vendor": sysfs_first(["/sys/class/dmi/id/sys_vendor"], "unknown"),
-            "product_name": sysfs_first(["/sys/class/dmi/id/product_name"], "unknown"),
-            "serial_number": sysfs_first(["/sys/class/dmi/id/product_serial"], "unknown"),
-            "uuid": sysfs_first(["/sys/class/dmi/id/product_uuid"], "unknown"),
-            "fqdn": socket.getfqdn(),
-        },
-        "gpu": {
-            "total_count": total_gpu_count,
-            "nvidia": {
-                "count": str(nvidia_gpu_count),
-                "driver_version": nvidia_driver_version,
-                "cuda_toolkit_version": cuda_toolkit_version,
-                "cuda_runtime_version": cuda_runtime_version,
-                "gpu_models": nvidia_gpu_names,
-                "serial_numbers": nvidia_query("serial"),
-                "uuids": nvidia_query("uuid"),
-                "memory_total_mb": nvidia_gpu_memory,
-                "compute_capabilities": nvidia_gpu_compute_cap,
-                "pci_bus_ids": nvidia_query("pci.bus_id"),
-                "persistence_mode": nvidia_query("persistence_mode", join_lines=False),
-                "compute_mode": nvidia_query("compute_mode", join_lines=False),
-            },
-            "amd": {"count": str(amd_gpu_count)},
-            "intel": {"count": str(intel_gpu_count)},
-        },
-        "network": {"interfaces": network_interfaces()},
-        "storage": {"devices": storage_devices()},
-    },
+    jq -c 'sort' <<< "$interfaces"
 }
 
-existing = {}
-if metadata_path.exists():
-    try:
-        existing = json.loads(metadata_path.read_text(encoding="utf-8"))
-    except Exception:
-        backup_path = metadata_path.with_suffix(metadata_path.suffix + ".invalid")
-        shutil.copy2(metadata_path, backup_path)
+storage_devices_json() {
+    local devices='{}'
+    local model name path rotational sectors
 
-def merge(a, b):
-    result = dict(a)
-    for key, value in b.items():
-        if isinstance(result.get(key), dict) and isinstance(value, dict):
-            result[key] = merge(result[key], value)
-        else:
-            result[key] = value
-    return result
+    for path in /sys/block/*; do
+        [[ -e "$path" ]] || continue
+        name="$(basename "$path")"
+        case "$name" in
+            loop*|ram*)
+                continue
+                ;;
+        esac
 
-metadata_path.parent.mkdir(parents=True, exist_ok=True)
-if metadata_path.exists():
-    shutil.copy2(metadata_path, str(metadata_path) + ".bak")
-metadata_path.write_text(json.dumps(merge(existing, hardware_metadata), indent=4, sort_keys=True) + "\n", encoding="utf-8")
-metadata_path.chmod(0o644)
-PY
+        sectors="$(int_value "$(sysfs_first 0 "${path}/size")")"
+        model="$(sysfs_first "" "${path}/device/model")"
+        rotational="$(sysfs_first "" "${path}/queue/rotational")"
+        devices="$(jq -c \
+            --arg name "$name" \
+            --arg model "$model" \
+            --arg rotational "$rotational" \
+            --argjson sectors "$sectors" \
+            '. + {($name): {
+                model: $model,
+                sectors: $sectors,
+                size_bytes: ($sectors * 512),
+                rotational: $rotational
+            }}' <<< "$devices")"
+    done
+
+    printf '%s\n' "$devices"
+}
+
+collect_hardware_metadata() {
+    local amd_gpu_count architecture bios_date bios_version cpu_model cuda_runtime_version cuda_toolkit_version
+    local existing_metadata fqdn gpu_count_lspci hardware_metadata intel_gpu_count mem_free_mb mem_total_mb
+    local metadata_dir metadata_tmp nvidia_compute_mode nvidia_driver_version nvidia_gpu_compute_cap
+    local nvidia_gpu_count nvidia_gpu_memory nvidia_gpu_names nvidia_gpu_pci_bus_ids nvidia_gpu_serials
+    local nvidia_gpu_uuids nvidia_persistence_mode processor_cores processor_count processor_threads_per_core
+    local processor_vcpus product_name product_serial product_uuid product_version storage_devices
+    local swap_free_mb swap_total_mb system_model system_vendor total_gpu_count
+
+    echo_info "Collecting hardware metadata..."
+
+    cpu_model="$(first_line "awk -F': ' '/model name/ {print \$2; exit}' /proc/cpuinfo")"
+    [[ -n "$cpu_model" ]] || cpu_model="Unknown"
+    architecture="$(uname -m 2>/dev/null || echo unknown)"
+    processor_count="$(int_value "$(first_line "awk -F': ' '/physical id/ {ids[\$2]=1} END {print length(ids)}' /proc/cpuinfo")")"
+    [[ "$processor_count" -gt 0 ]] || processor_count=1
+    processor_cores="$(int_value "$(first_line "awk -F': ' '/cpu cores/ {print \$2; exit}' /proc/cpuinfo")")"
+    processor_vcpus="$(int_value "$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 0)")"
+    if [[ "$processor_cores" -gt 0 && "$processor_vcpus" -gt 0 ]]; then
+        processor_threads_per_core=$((processor_vcpus / processor_cores))
+    else
+        processor_threads_per_core=0
+    fi
+
+    mem_total_mb=$(( $(int_value "$(first_line "awk '/^MemTotal:/ {print \$2; exit}' /proc/meminfo")") / 1024 ))
+    mem_free_mb=$(( $(int_value "$(first_line "awk '/^MemFree:/ {print \$2; exit}' /proc/meminfo")") / 1024 ))
+    swap_total_mb=$(( $(int_value "$(first_line "awk '/^SwapTotal:/ {print \$2; exit}' /proc/meminfo")") / 1024 ))
+    swap_free_mb=$(( $(int_value "$(first_line "awk '/^SwapFree:/ {print \$2; exit}' /proc/meminfo")") / 1024 ))
+
+    system_vendor="$(sysfs_first "unknown" /sys/class/dmi/id/sys_vendor)"
+    system_model="$(sysfs_first "unknown" /sys/class/dmi/id/product_name)"
+    product_name="$system_model"
+    product_version="$(sysfs_first "unknown" /sys/class/dmi/id/product_version)"
+    product_serial="$(sysfs_first "unknown" /sys/class/dmi/id/product_serial)"
+    product_uuid="$(sysfs_first "unknown" /sys/class/dmi/id/product_uuid)"
+    bios_version="$(sysfs_first "unknown" /sys/class/dmi/id/bios_version)"
+    bios_date="$(sysfs_first "unknown" /sys/class/dmi/id/bios_date)"
+    fqdn="$(hostname -f 2>/dev/null || hostname)"
+
+    gpu_count_lspci="$(int_value "$(run_capture "lspci 2>/dev/null | grep -icE 'VGA|3D controller.*NVIDIA|Display.*NVIDIA'")")"
+    nvidia_gpu_count="$(int_value "$(nvidia_query count true)")"
+    amd_gpu_count="$(int_value "$(run_capture "lspci 2>/dev/null | grep -icE 'VGA.*AMD|3D.*AMD|Display.*AMD'")")"
+    intel_gpu_count="$(int_value "$(run_capture "lspci 2>/dev/null | grep -icE 'VGA.*Intel|Display.*Intel.*Graphics'")")"
+    if [[ "$nvidia_gpu_count" -gt 0 ]]; then
+        total_gpu_count=$((nvidia_gpu_count + amd_gpu_count + intel_gpu_count))
+    else
+        total_gpu_count=$((gpu_count_lspci + amd_gpu_count + intel_gpu_count))
+    fi
+
+    nvidia_driver_version="$(nvidia_query driver_version true)"
+    nvidia_gpu_names="$(nvidia_query name)"
+    nvidia_gpu_serials="$(nvidia_query serial)"
+    nvidia_gpu_uuids="$(nvidia_query uuid)"
+    nvidia_gpu_memory="$(nvidia_query memory.total)"
+    nvidia_gpu_compute_cap="$(nvidia_query compute_cap)"
+    nvidia_gpu_pci_bus_ids="$(nvidia_query pci.bus_id)"
+    nvidia_persistence_mode="$(nvidia_query persistence_mode true)"
+    nvidia_compute_mode="$(nvidia_query compute_mode true)"
+    cuda_toolkit_version="$(first_line "nvcc --version 2>/dev/null | grep 'release' | sed 's/.*release \([0-9.]*\).*/\1/'")"
+    cuda_runtime_version="$(first_line "ldconfig -p 2>/dev/null | grep -oP 'libcudart\.so\.\K[0-9.]+'")"
+
+    storage_devices="$(storage_devices_json)"
+
+    hardware_metadata="$(jq -n \
+        --arg cpu_model "$cpu_model" \
+        --arg architecture "$architecture" \
+        --argjson processor_count "$processor_count" \
+        --argjson processor_cores "$processor_cores" \
+        --argjson processor_threads_per_core "$processor_threads_per_core" \
+        --argjson processor_vcpus "$processor_vcpus" \
+        --argjson mem_total_mb "$mem_total_mb" \
+        --argjson mem_free_mb "$mem_free_mb" \
+        --argjson swap_total_mb "$swap_total_mb" \
+        --argjson swap_free_mb "$swap_free_mb" \
+        --argjson total_gpu_count "$total_gpu_count" \
+        --arg nvidia_gpu_count "$nvidia_gpu_count" \
+        --arg nvidia_driver_version "$nvidia_driver_version" \
+        --arg cuda_toolkit_version "$cuda_toolkit_version" \
+        --arg cuda_runtime_version "$cuda_runtime_version" \
+        --arg nvidia_gpu_names "$nvidia_gpu_names" \
+        --arg nvidia_gpu_serials "$nvidia_gpu_serials" \
+        --arg nvidia_gpu_uuids "$nvidia_gpu_uuids" \
+        --arg nvidia_gpu_memory "$nvidia_gpu_memory" \
+        --arg nvidia_gpu_compute_cap "$nvidia_gpu_compute_cap" \
+        --arg nvidia_gpu_pci_bus_ids "$nvidia_gpu_pci_bus_ids" \
+        --arg nvidia_persistence_mode "$nvidia_persistence_mode" \
+        --arg nvidia_compute_mode "$nvidia_compute_mode" \
+        --arg amd_gpu_count "$amd_gpu_count" \
+        --arg intel_gpu_count "$intel_gpu_count" \
+        --arg system_vendor "$system_vendor" \
+        --arg system_model "$system_model" \
+        --arg product_name "$product_name" \
+        --arg product_version "$product_version" \
+        --arg product_serial "$product_serial" \
+        --arg product_uuid "$product_uuid" \
+        --arg bios_version "$bios_version" \
+        --arg bios_date "$bios_date" \
+        --arg fqdn "$fqdn" \
+        --argjson interfaces "$(network_interfaces_json)" \
+        --argjson storage_devices "$storage_devices" \
+        '{
+            hardware_summary: {
+                cpu_model: $cpu_model,
+                total_cpus: $processor_count,
+                total_cores: $processor_cores,
+                total_vcpus: $processor_vcpus,
+                total_memory_mb: $mem_total_mb,
+                total_gpus: $total_gpu_count,
+                gpu_models: $nvidia_gpu_names,
+                nvidia_driver_version: $nvidia_driver_version,
+                cuda_toolkit_version: $cuda_toolkit_version,
+                cuda_runtime_version: $cuda_runtime_version,
+                gpu_memory_total_mb: $nvidia_gpu_memory,
+                gpu_compute_capabilities: $nvidia_gpu_compute_cap,
+                system_vendor: $system_vendor,
+                system_model: $system_model
+            },
+            hardware: {
+                cpu: {
+                    architecture: $architecture,
+                    processor_count: $processor_count,
+                    processor_cores: $processor_cores,
+                    processor_threads_per_core: $processor_threads_per_core,
+                    processor_vcpus: $processor_vcpus,
+                    model_name: $cpu_model
+                },
+                memory: {
+                    total_mb: $mem_total_mb,
+                    free_mb: $mem_free_mb,
+                    swap_total_mb: $swap_total_mb,
+                    swap_free_mb: $swap_free_mb
+                },
+                motherboard: {
+                    manufacturer: $system_vendor,
+                    product_name: $product_name,
+                    product_version: $product_version
+                },
+                bios: {
+                    vendor: $bios_version,
+                    version: $bios_version,
+                    date: $bios_date
+                },
+                system: {
+                    vendor: $system_vendor,
+                    product_name: $product_name,
+                    serial_number: $product_serial,
+                    uuid: $product_uuid,
+                    fqdn: $fqdn
+                },
+                gpu: {
+                    total_count: $total_gpu_count,
+                    nvidia: {
+                        count: $nvidia_gpu_count,
+                        driver_version: $nvidia_driver_version,
+                        cuda_toolkit_version: $cuda_toolkit_version,
+                        cuda_runtime_version: $cuda_runtime_version,
+                        gpu_models: $nvidia_gpu_names,
+                        serial_numbers: $nvidia_gpu_serials,
+                        uuids: $nvidia_gpu_uuids,
+                        memory_total_mb: $nvidia_gpu_memory,
+                        compute_capabilities: $nvidia_gpu_compute_cap,
+                        pci_bus_ids: $nvidia_gpu_pci_bus_ids,
+                        persistence_mode: $nvidia_persistence_mode,
+                        compute_mode: $nvidia_compute_mode
+                    },
+                    amd: {count: $amd_gpu_count},
+                    intel: {count: $intel_gpu_count}
+                },
+                network: {interfaces: $interfaces},
+                storage: {devices: $storage_devices}
+            }
+        }')"
+
+    metadata_dir="$(dirname "$METADATA_PATH")"
+    install -d -m 0755 "$metadata_dir"
+
+    existing_metadata="{}"
+    if [[ -f "$METADATA_PATH" ]]; then
+        if jq -e . "$METADATA_PATH" >/dev/null 2>&1; then
+            cp "$METADATA_PATH" "${METADATA_PATH}.bak"
+            existing_metadata="$(cat "$METADATA_PATH")"
+        else
+            cp "$METADATA_PATH" "${METADATA_PATH}.invalid"
+        fi
+    fi
+
+    metadata_tmp="$(mktemp)"
+    jq -S -s '.[0] * .[1]' \
+        <(printf '%s\n' "$existing_metadata") \
+        <(printf '%s\n' "$hardware_metadata") > "$metadata_tmp"
+    install -m 0644 "$metadata_tmp" "$METADATA_PATH"
+    rm -f "$metadata_tmp"
 }
 
 install_fleet_package() {

--- a/setup-raw.sh
+++ b/setup-raw.sh
@@ -34,6 +34,7 @@ INFLUX_PASSWORD="${INFLUX_PASSWORD:-LocaFluxCapacity2024}"
 INFLUX_USERNAME="${INFLUX_USERNAME:-lp}"
 METADATA_PATH="${METADATA_PATH:-/etc/brev/metadata.json}"
 SKIP_HOSTNAME_CONF=false
+TOLERATE_FAILURES=false
 
 echo_info() {
     printf '\033[1;34m[INFO]\033[0m %s\n' "$*"
@@ -50,8 +51,42 @@ echo_error() {
 require_root() {
     if [[ "$(id -u)" -ne 0 ]]; then
         echo_error "Run this script as root or with sudo."
-        exit 1
+        return 1
     fi
+}
+
+exit_with_status() {
+    local status="$1"
+
+    if [[ "$status" -ne 0 && "$TOLERATE_FAILURES" == true ]]; then
+        echo_warn "setup-raw.sh failed with exit code ${status}; --tolerate-failures enabled, exiting 0."
+        exit 0
+    fi
+
+    exit "$status"
+}
+
+parse_tolerance_flag() {
+    local arg
+
+    for arg in "$@"; do
+        if [[ "$arg" == "--tolerate-failures" ]]; then
+            TOLERATE_FAILURES=true
+        fi
+    done
+}
+
+run_main() {
+    local status
+
+    set +e
+    (
+        set -Eeuo pipefail
+        main "$@"
+    )
+    status="$?"
+
+    exit_with_status "$status"
 }
 
 wait_for_apt_lock() {
@@ -82,7 +117,7 @@ wait_for_apt_lock() {
 
         if (( elapsed >= lock_wait_time )); then
             echo_error "Timeout waiting for apt/dpkg locks to be released."
-            exit 1
+            return 1
         fi
 
         sleep "$interval"
@@ -222,6 +257,9 @@ parse_args() {
             --skip-hostname-conf)
                 SKIP_HOSTNAME_CONF=true
                 ;;
+            --tolerate-failures)
+                TOLERATE_FAILURES=true
+                ;;
             skip_hostname_conf=*)
                 value="${arg#*=}"
                 case "$value" in
@@ -332,7 +370,7 @@ set_instance_hostname() {
 install_base_packages() {
     if ! command -v apt-get >/dev/null 2>&1; then
         echo_error "This raw installer currently supports apt-based Debian/Ubuntu instances."
-        exit 1
+        return 1
     fi
 
     echo_info "Installing base packages..."
@@ -397,7 +435,7 @@ wait_for_influxdb() {
     until influx ping >/dev/null 2>&1; do
         if (( elapsed >= timeout )); then
             echo_error "InfluxDB did not become available within ${timeout}s."
-            exit 1
+            return 1
         fi
         sleep "$interval"
         elapsed=$((elapsed + interval))
@@ -828,8 +866,8 @@ collect_hardware_metadata() {
 }
 
 main() {
-    require_root
     parse_args "$@"
+    require_root
     readonly HOSTID="$(detect_hostid)"
     export HOSTID DOMAIN_VALUE GRAFANA_SUBPATH
 
@@ -847,4 +885,5 @@ main() {
     echo_info "Raw metrics collector setup completed successfully."
 }
 
-main "$@"
+parse_tolerance_flag "$@"
+run_main "$@"

--- a/setup-raw.sh
+++ b/setup-raw.sh
@@ -119,6 +119,21 @@ parse_args() {
             --skip-hostname-conf)
                 SKIP_HOSTNAME_CONF=true
                 ;;
+            skip_hostname_conf=*)
+                value="${arg#*=}"
+                case "$value" in
+                    true|TRUE|True|yes|YES|Yes|1)
+                        SKIP_HOSTNAME_CONF=true
+                        ;;
+                    *)
+                        SKIP_HOSTNAME_CONF=false
+                        ;;
+                esac
+                ;;
+            asset_base_url=*|ASSET_BASE_URL=*)
+                value="${arg#*=}"
+                ASSET_BASE_URL="$value"
+                ;;
             aws_region=*|AWS_REGION=*)
                 value="${arg#*=}"
                 AWS_REGION_VALUE="$value"
@@ -142,6 +157,34 @@ parse_args() {
             domain=*|DOMAIN=*)
                 value="${arg#*=}"
                 DOMAIN_VALUE="$value"
+                ;;
+            grafana.subpath=*|grafana_subpath=*|GRAFANA_SUBPATH=*)
+                value="${arg#*=}"
+                GRAFANA_SUBPATH="$value"
+                ;;
+            host_prefix=*|HOST_PREFIX=*)
+                value="${arg#*=}"
+                HOST_PREFIX="$value"
+                ;;
+            influx.bucket=*|influx_bucket=*|INFLUX_BUCKET=*)
+                value="${arg#*=}"
+                INFLUX_BUCKET="$value"
+                ;;
+            influx.org=*|influx_org=*|INFLUX_ORG=*)
+                value="${arg#*=}"
+                INFLUX_ORG="$value"
+                ;;
+            influx.password=*|influx_password=*|INFLUX_PASSWORD=*)
+                value="${arg#*=}"
+                INFLUX_PASSWORD="$value"
+                ;;
+            influx.username=*|influx_username=*|INFLUX_USERNAME=*)
+                value="${arg#*=}"
+                INFLUX_USERNAME="$value"
+                ;;
+            metadata_path=*|METADATA_PATH=*)
+                value="${arg#*=}"
+                METADATA_PATH="$value"
                 ;;
             fleet_amd64_url=*|FLEET_AMD64_URL=*)
                 value="${arg#*=}"

--- a/setup-raw.sh
+++ b/setup-raw.sh
@@ -14,7 +14,10 @@ readonly DEFAULT_ASSET_BASE_URL="https://raw.githubusercontent.com/Shiftius/ansi
 readonly DEFAULT_FLEET_AMD64_URL="https://github.com/Shiftius/ansible-gpu-metrics-collector/releases/download/pkg-1.0.0/f2a389a0c40047587c32daafd34d407bc130075f8d29decf2c0aad5f60464043"
 readonly DEFAULT_FLEET_PKG_AMD64="fleet-1.0.0_amd64.deb"
 
+SCRIPT_SOURCE="${BASH_SOURCE[0]:-}"
+SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_SOURCE")" >/dev/null 2>&1 && pwd || true)"
 ASSET_BASE_URL="${ASSET_BASE_URL:-$DEFAULT_ASSET_BASE_URL}"
+ASSET_DIR="${ASSET_DIR:-}"
 AWS_REGION_VALUE="${AWS_REGION:-${aws_region:-us-west-2}}"
 AWS_TIMESTREAM_ACCESS_KEY_VALUE="${AWS_TIMESTREAM_ACCESS_KEY:-${aws_timestream_access_key:-empty-access-key}}"
 AWS_TIMESTREAM_SECRET_KEY_VALUE="${AWS_TIMESTREAM_SECRET_KEY:-${aws_timestream_secret_key:-empty-secret-key}}"
@@ -132,6 +135,26 @@ download_file() {
     fi
     curl -fsSL "$url" -o "$dest"
     chmod "$mode" "$dest"
+}
+
+copy_or_download_asset() {
+    local relative_path="$1"
+    local dest="$2"
+    local mode="${3:-0644}"
+    local asset_root
+    local local_path
+
+    for asset_root in "$ASSET_DIR" "$SCRIPT_DIR"; do
+        [[ -n "$asset_root" ]] || continue
+        local_path="${asset_root}/${relative_path}"
+        if [[ -f "$local_path" ]]; then
+            install -d -m 0755 "$(dirname "$dest")"
+            install -m "$mode" "$local_path" "$dest"
+            return
+        fi
+    done
+
+    download_file "${ASSET_BASE_URL}/${relative_path}" "$dest" "$mode"
 }
 
 escape_sed_replacement() {
@@ -349,8 +372,14 @@ configure_repositories() {
 }
 
 install_metrics_packages() {
+    local pkg_path="/opt/${FLEET_PKG_AMD64}"
+
     echo_info "Installing metrics packages..."
-    apt_install grafana influxdb2 influxdb2-cli telegraf wget
+    download_file "$FLEET_AMD64_URL" "$pkg_path" 0644
+    if ! apt_install grafana influxdb2 influxdb2-cli telegraf "$pkg_path"; then
+        echo_warn "Combined metrics and fleet package install failed; retrying metrics packages without fleet."
+        apt_install grafana influxdb2 influxdb2-cli telegraf
+    fi
 }
 
 systemctl_enable_restart() {
@@ -513,7 +542,7 @@ configure_grafana() {
     install -d -m 0755 /var/lib/grafana/dashboards
 
     grafana_template="$(mktemp)"
-    download_file "${ASSET_BASE_URL}/roles/telegraf_config/templates/grafana/grafana.ini" "$grafana_template" 0644
+    copy_or_download_asset "roles/telegraf_config/templates/grafana/grafana.ini" "$grafana_template" 0644
     render_grafana_ini "$grafana_template" /etc/grafana/grafana.ini
     rm -f "$grafana_template"
 
@@ -555,7 +584,7 @@ providers:
     path: /var/lib/grafana/dashboards
 EOF
 
-    download_file "${ASSET_BASE_URL}/roles/telegraf_config/templates/grafana/dashboard.json" /var/lib/grafana/dashboards/metrics.json 0644
+    copy_or_download_asset "roles/telegraf_config/templates/grafana/dashboard.json" /var/lib/grafana/dashboards/metrics.json 0644
     chown -R grafana:grafana /var/lib/grafana/dashboards
     systemctl_enable_restart grafana-server
 }
@@ -798,17 +827,6 @@ collect_hardware_metadata() {
     rm -f "$metadata_tmp"
 }
 
-install_fleet_package() {
-    local pkg_path="/opt/${FLEET_PKG_AMD64}"
-
-    echo_info "Installing fleet package..."
-    download_file "$FLEET_AMD64_URL" "$pkg_path" 0644
-    wait_for_apt_lock
-    if ! NEEDRESTART_SUSPEND=1 DEBIAN_FRONTEND=noninteractive apt-get install -y "$pkg_path"; then
-        echo_warn "Fleet package installation failed; continuing to match the non-failing Ansible role."
-    fi
-}
-
 main() {
     require_root
     parse_args "$@"
@@ -825,7 +843,6 @@ main() {
     configure_influxdb
     configure_telegraf
     configure_grafana
-    install_fleet_package
 
     echo_info "Raw metrics collector setup completed successfully."
 }

--- a/setup-raw.sh
+++ b/setup-raw.sh
@@ -97,6 +97,29 @@ apt_update() {
     DEBIAN_FRONTEND=noninteractive apt-get update
 }
 
+apt_package_installed() {
+    dpkg-query -W -f='${Status}' "$1" 2>/dev/null | grep -q "install ok installed"
+}
+
+apt_install_missing() {
+    local missing=()
+    local package
+
+    for package in "$@"; do
+        if ! apt_package_installed "$package"; then
+            missing+=("$package")
+        fi
+    done
+
+    if [[ ${#missing[@]} -eq 0 ]]; then
+        echo_info "Base packages already installed."
+        return
+    fi
+
+    apt_update
+    apt_install "${missing[@]}"
+}
+
 download_file() {
     local url="$1"
     local dest="$2"
@@ -290,8 +313,7 @@ install_base_packages() {
     fi
 
     echo_info "Installing base packages..."
-    apt_update
-    apt_install ca-certificates curl dmidecode gnupg jq lshw pciutils wget
+    apt_install_missing ca-certificates curl dmidecode gnupg jq lshw pciutils wget
 }
 
 configure_repositories() {
@@ -365,6 +387,7 @@ configure_influxdb() {
     if [[ -z "$bucket_id" ]]; then
         echo_info "Creating InfluxDB organization, bucket, and admin token..."
         influx setup \
+            --name default \
             --username "$INFLUX_USERNAME" \
             --password "$INFLUX_PASSWORD" \
             --org "$INFLUX_ORG" \

--- a/setup-raw.sh
+++ b/setup-raw.sh
@@ -2,7 +2,7 @@
 
 if [[ ${-} == *x* ]]; then
     echo "[ERROR] Do not run this script with shell tracing enabled; it can expose credentials." >&2
-    exit 1
+    exit 0
 fi
 
 set -Eeuo pipefail

--- a/setup-raw.sh
+++ b/setup-raw.sh
@@ -34,7 +34,9 @@ INFLUX_PASSWORD="${INFLUX_PASSWORD:-LocaFluxCapacity2024}"
 INFLUX_USERNAME="${INFLUX_USERNAME:-lp}"
 METADATA_PATH="${METADATA_PATH:-/etc/brev/metadata.json}"
 SKIP_HOSTNAME_CONF=false
-TOLERATE_FAILURES=false
+# Failures are tolerated by default so parent bootstrap/orchestration scripts do
+# not fail closed if this metrics setup encounters an issue.
+TOLERATE_FAILURES=true
 
 echo_info() {
     printf '\033[1;34m[INFO]\033[0m %s\n' "$*"
@@ -59,7 +61,7 @@ exit_with_status() {
     local status="$1"
 
     if [[ "$status" -ne 0 && "$TOLERATE_FAILURES" == true ]]; then
-        echo_warn "setup-raw.sh failed with exit code ${status}; --tolerate-failures enabled, exiting 0."
+        echo_warn "setup-raw.sh failed with exit code ${status}; failure tolerance enabled, exiting 0."
         exit 0
     fi
 
@@ -70,9 +72,14 @@ parse_tolerance_flag() {
     local arg
 
     for arg in "$@"; do
-        if [[ "$arg" == "--tolerate-failures" ]]; then
-            TOLERATE_FAILURES=true
-        fi
+        case "$arg" in
+            --tolerate-failures)
+                TOLERATE_FAILURES=true
+                ;;
+            --strict-failures)
+                TOLERATE_FAILURES=false
+                ;;
+        esac
     done
 }
 
@@ -259,6 +266,9 @@ parse_args() {
                 ;;
             --tolerate-failures)
                 TOLERATE_FAILURES=true
+                ;;
+            --strict-failures)
+                TOLERATE_FAILURES=false
                 ;;
             skip_hostname_conf=*)
                 value="${arg#*=}"

--- a/setup-raw.sh
+++ b/setup-raw.sh
@@ -1,0 +1,688 @@
+#!/usr/bin/env bash
+
+if [[ ${-} == *x* ]]; then
+    echo "[ERROR] Do not run this script with shell tracing enabled; it can expose credentials." >&2
+    exit 1
+fi
+
+set -Eeuo pipefail
+set +x
+
+export HISTFILE=/dev/null
+
+readonly DEFAULT_ASSET_BASE_URL="https://raw.githubusercontent.com/Shiftius/ansible-gpu-metrics-collector/main"
+readonly DEFAULT_FLEET_AMD64_URL="https://github.com/Shiftius/ansible-gpu-metrics-collector/releases/download/pkg-1.0.0/f2a389a0c40047587c32daafd34d407bc130075f8d29decf2c0aad5f60464043"
+readonly DEFAULT_FLEET_PKG_AMD64="fleet-1.0.0_amd64.deb"
+
+ASSET_BASE_URL="${ASSET_BASE_URL:-$DEFAULT_ASSET_BASE_URL}"
+AWS_REGION_VALUE="${AWS_REGION:-${aws_region:-us-west-2}}"
+AWS_TIMESTREAM_ACCESS_KEY_VALUE="${AWS_TIMESTREAM_ACCESS_KEY:-${aws_timestream_access_key:-empty-access-key}}"
+AWS_TIMESTREAM_SECRET_KEY_VALUE="${AWS_TIMESTREAM_SECRET_KEY:-${aws_timestream_secret_key:-empty-secret-key}}"
+AWS_TIMESTREAM_DATABASE_VALUE="${AWS_TIMESTREAM_DATABASE:-${aws_timestream_database:-empty-database}}"
+DOMAIN_VALUE="${DOMAIN:-${domain:-domain.com}}"
+ENVIRONMENT_ID_VALUE="${ENVIRONMENT_ID:-${environmentID:-}}"
+FLEET_AMD64_URL="${FLEET_AMD64_URL:-${fleet_amd64_url:-$DEFAULT_FLEET_AMD64_URL}}"
+FLEET_PKG_AMD64="${FLEET_PKG_AMD64:-${fleet_pkg_amd64:-$DEFAULT_FLEET_PKG_AMD64}}"
+GRAFANA_SUBPATH="${GRAFANA_SUBPATH:-metrics}"
+HOST_PREFIX="${HOST_PREFIX:-brev}"
+INFLUX_BUCKET="${INFLUX_BUCKET:-lp}"
+INFLUX_ORG="${INFLUX_ORG:-lp}"
+INFLUX_PASSWORD="${INFLUX_PASSWORD:-LocaFluxCapacity2024}"
+INFLUX_USERNAME="${INFLUX_USERNAME:-lp}"
+METADATA_PATH="${METADATA_PATH:-/etc/brev/metadata.json}"
+SKIP_HOSTNAME_CONF=false
+
+echo_info() {
+    printf '\033[1;34m[INFO]\033[0m %s\n' "$*"
+}
+
+echo_warn() {
+    printf '\033[1;33m[WARN]\033[0m %s\n' "$*" >&2
+}
+
+echo_error() {
+    printf '\033[1;31m[ERROR]\033[0m %s\n' "$*" >&2
+}
+
+require_root() {
+    if [[ "$(id -u)" -ne 0 ]]; then
+        echo_error "Run this script as root or with sudo."
+        exit 1
+    fi
+}
+
+wait_for_apt_lock() {
+    local elapsed=0
+    local interval=5
+    local lock_wait_time=360
+    local locks=(
+        /var/lib/dpkg/lock
+        /var/lib/dpkg/lock-frontend
+        /var/lib/apt/lists/lock
+        /var/cache/apt/archives/lock
+    )
+
+    echo_info "Waiting for apt/dpkg locks to be released..."
+    while true; do
+        local busy=false
+        for lock_file in "${locks[@]}"; do
+            if [[ -e "$lock_file" ]] && fuser "$lock_file" >/dev/null 2>&1; then
+                busy=true
+                break
+            fi
+        done
+
+        if [[ "$busy" == false ]]; then
+            echo_info "Apt locks are free."
+            return
+        fi
+
+        if (( elapsed >= lock_wait_time )); then
+            echo_error "Timeout waiting for apt/dpkg locks to be released."
+            exit 1
+        fi
+
+        sleep "$interval"
+        elapsed=$((elapsed + interval))
+    done
+}
+
+apt_install() {
+    wait_for_apt_lock
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "$@"
+}
+
+apt_update() {
+    wait_for_apt_lock
+    DEBIAN_FRONTEND=noninteractive apt-get update
+}
+
+download_file() {
+    local url="$1"
+    local dest="$2"
+    local mode="${3:-0644}"
+    local dest_dir
+
+    dest_dir="$(dirname "$dest")"
+    if [[ ! -d "$dest_dir" ]]; then
+        install -d -m 0755 "$dest_dir"
+    fi
+    curl -fsSL "$url" -o "$dest"
+    chmod "$mode" "$dest"
+}
+
+parse_args() {
+    local arg value
+
+    for arg in "$@"; do
+        case "$arg" in
+            --skip-hostname-conf)
+                SKIP_HOSTNAME_CONF=true
+                ;;
+            aws_region=*|AWS_REGION=*)
+                value="${arg#*=}"
+                AWS_REGION_VALUE="$value"
+                ;;
+            aws_timestream_access_key=*|AWS_TIMESTREAM_ACCESS_KEY=*)
+                value="${arg#*=}"
+                AWS_TIMESTREAM_ACCESS_KEY_VALUE="$value"
+                ;;
+            aws_timestream_secret_key=*|AWS_TIMESTREAM_SECRET_KEY=*)
+                value="${arg#*=}"
+                AWS_TIMESTREAM_SECRET_KEY_VALUE="$value"
+                ;;
+            aws_timestream_database=*|AWS_TIMESTREAM_DATABASE=*)
+                value="${arg#*=}"
+                AWS_TIMESTREAM_DATABASE_VALUE="$value"
+                ;;
+            environmentID=*|ENVIRONMENT_ID=*)
+                value="${arg#*=}"
+                ENVIRONMENT_ID_VALUE="$value"
+                ;;
+            domain=*|DOMAIN=*)
+                value="${arg#*=}"
+                DOMAIN_VALUE="$value"
+                ;;
+            fleet_amd64_url=*|FLEET_AMD64_URL=*)
+                value="${arg#*=}"
+                FLEET_AMD64_URL="$value"
+                ;;
+            fleet_pkg_amd64=*|FLEET_PKG_AMD64=*)
+                value="${arg#*=}"
+                FLEET_PKG_AMD64="$value"
+                ;;
+            *)
+                echo_warn "Ignoring unsupported argument: ${arg%%=*}"
+                ;;
+        esac
+    done
+
+    unset arg value
+    set --
+}
+
+detect_hostid() {
+    if [[ -n "$ENVIRONMENT_ID_VALUE" ]]; then
+        printf '%s' "$ENVIRONMENT_ID_VALUE"
+        return
+    fi
+
+    hostname -f 2>/dev/null || hostname
+}
+
+set_instance_hostname() {
+    local hostid="$1"
+    local desired_hostname="${HOST_PREFIX}-${hostid}"
+
+    if [[ "$SKIP_HOSTNAME_CONF" == true ]]; then
+        echo_info "Leaving hostname unchanged because --skip-hostname-conf was provided."
+        return
+    fi
+
+    echo_info "Setting hostname to ${desired_hostname}..."
+    hostnamectl set-hostname "$desired_hostname"
+}
+
+install_base_packages() {
+    if ! command -v apt-get >/dev/null 2>&1; then
+        echo_error "This raw installer currently supports apt-based Debian/Ubuntu instances."
+        exit 1
+    fi
+
+    echo_info "Installing base packages..."
+    apt_update
+    apt_install ca-certificates curl dmidecode gnupg jq lshw pciutils python3 wget
+}
+
+configure_repositories() {
+    echo_info "Configuring InfluxData and Grafana apt repositories..."
+
+    rm -f \
+        /etc/apt/sources.list.d/influxdata.list \
+        /etc/apt/sources.list.d/influxdb.list \
+        /etc/apt/keyrings/influxdata-apt-keyring.asc \
+        /etc/apt/keyrings/influxdata.gpg \
+        /etc/apt/sources.list.d/grafana.list \
+        /etc/apt/keyrings/grafana.asc \
+        /etc/apt/keyrings/grafana.key \
+        /usr/share/keyrings/grafana.key \
+        /usr/share/keyrings/grafana.asc
+
+    install -d -m 0755 /etc/apt/trusted.gpg.d /usr/share/keyrings
+    curl -fsSL https://repos.influxdata.com/influxdata-archive.key \
+        | gpg --dearmor > /etc/apt/trusted.gpg.d/influxdata-archive_compat.gpg
+    chmod 0644 /etc/apt/trusted.gpg.d/influxdata-archive_compat.gpg
+
+    printf '%s\n' \
+        "deb [signed-by=/etc/apt/trusted.gpg.d/influxdata-archive_compat.gpg] https://repos.influxdata.com/debian stable main" \
+        > /etc/apt/sources.list.d/influxdata.list
+
+    curl -fsSL https://apt.grafana.com/gpg.key -o /usr/share/keyrings/grafana.key
+    chmod 0644 /usr/share/keyrings/grafana.key
+    printf '%s\n' \
+        "deb [signed-by=/usr/share/keyrings/grafana.key] https://apt.grafana.com stable main" \
+        > /etc/apt/sources.list.d/grafana.list
+
+    apt_update
+}
+
+install_metrics_packages() {
+    echo_info "Installing metrics packages..."
+    apt_install grafana influxdb2 influxdb2-cli telegraf wget
+}
+
+systemctl_enable_restart() {
+    local unit="$1"
+    systemctl enable "$unit"
+    systemctl restart "$unit"
+}
+
+wait_for_influxdb() {
+    local elapsed=0
+    local interval=2
+    local timeout=90
+
+    echo_info "Waiting for InfluxDB to become available..."
+    until influx ping >/dev/null 2>&1; do
+        if (( elapsed >= timeout )); then
+            echo_error "InfluxDB did not become available within ${timeout}s."
+            exit 1
+        fi
+        sleep "$interval"
+        elapsed=$((elapsed + interval))
+    done
+}
+
+configure_influxdb() {
+    local bucket_id auth_id
+
+    echo_info "Starting InfluxDB..."
+    systemctl enable influxdb
+    systemctl start influxdb
+    wait_for_influxdb
+
+    bucket_id="$(influx bucket list 2>/dev/null | awk -v bucket="$INFLUX_BUCKET" '$0 ~ bucket {print $1; exit}' || true)"
+    if [[ -z "$bucket_id" ]]; then
+        echo_info "Creating InfluxDB organization, bucket, and admin token..."
+        influx setup \
+            --username "$INFLUX_USERNAME" \
+            --password "$INFLUX_PASSWORD" \
+            --org "$INFLUX_ORG" \
+            --bucket "$INFLUX_BUCKET" \
+            --retention 30d \
+            --token "$INFLUX_PASSWORD" \
+            --force >/dev/null
+        bucket_id="$(influx bucket list 2>/dev/null | awk -v bucket="$INFLUX_BUCKET" '$0 ~ bucket {print $1; exit}' || true)"
+    fi
+
+    auth_id="$(influx v1 auth list 2>/dev/null | awk -v bucket="$INFLUX_BUCKET" '$0 ~ bucket {print $1; exit}' || true)"
+    if [[ -n "$bucket_id" && -z "$auth_id" ]]; then
+        echo_info "Creating InfluxDB v1 compatibility auth..."
+        influx v1 auth create \
+            --username "$INFLUX_USERNAME" \
+            --password "$INFLUX_PASSWORD" \
+            --org "$INFLUX_ORG" \
+            --read-bucket "$bucket_id" >/dev/null
+    else
+        echo_info "InfluxDB bucket/auth already exists."
+    fi
+}
+
+configure_telegraf() {
+    echo_info "Writing Telegraf configuration..."
+
+    install -d -m 0750 -o telegraf -g telegraf /etc/telegraf
+    install -d -m 0755 /var/log/telegraf
+
+    cat > /etc/default/telegraf <<EOF
+LP_STACK_NAME="${HOSTID}"
+AWS_REGION="${AWS_REGION_VALUE}"
+AWS_ACCESS_KEY="${AWS_TIMESTREAM_ACCESS_KEY_VALUE}"
+AWS_SECRET_KEY="${AWS_TIMESTREAM_SECRET_KEY_VALUE}"
+AWS_TIMESTREAM_DB="${AWS_TIMESTREAM_DATABASE_VALUE}"
+EOF
+    chown telegraf:telegraf /etc/default/telegraf
+    chmod 0640 /etc/default/telegraf
+
+    cat > /etc/telegraf/telegraf.conf <<EOF
+## Configure Telegraf Global Tags
+[global_tags]
+
+## Configure Telegraf Agent
+[agent]
+  interval = "30s"
+  round_interval = true
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  collection_jitter = "0s"
+  flush_interval = "15s"
+  flush_jitter = "0s"
+  precision = ""
+  hostname = "\${LP_STACK_NAME}"
+  omit_hostname = false
+  logfile = "/var/log/telegraf/telegraf.log"
+
+## Configure Telegraf Inputs
+
+[[inputs.cpu]]
+  percpu = false
+[[inputs.disk]]
+ ignore_fs = ["tmpfs", "devtmpfs", "devfs", "iso9660", "overlay", "aufs", "squashfs", "shm"]
+[[inputs.diskio]]
+ devices = ["sd*", "vd*", "nv*"]
+[[inputs.net]]
+[[inputs.mem]]
+[[inputs.system]]
+[[inputs.nvidia_smi]]
+[[inputs.procstat]]
+  pattern = "cloudflared"
+
+## Configure Telegraf Outputs
+[[outputs.timestream]]
+  region = "\${AWS_REGION}"
+  access_key = "\${AWS_ACCESS_KEY}"
+  secret_key = "\${AWS_SECRET_KEY}"
+  database_name = "\${AWS_TIMESTREAM_DB}"
+  describe_database_on_start = false
+  mapping_mode = "multi-table"
+  create_table_if_not_exists = true
+  create_table_magnetic_store_retention_period_in_days = 365
+  create_table_memory_store_retention_period_in_hours = 24
+
+
+[[outputs.influxdb_v2]]
+  urls = ["http://127.0.0.1:8086"]
+  token = "${INFLUX_PASSWORD}"
+  organization = "${INFLUX_ORG}"
+  bucket = "${INFLUX_BUCKET}"
+EOF
+
+    chown -R telegraf:telegraf /etc/telegraf
+    chmod 0750 /etc/telegraf
+    chmod 0640 /etc/telegraf/telegraf.conf
+    usermod -a -G adm telegraf
+    systemctl_enable_restart telegraf
+}
+
+render_grafana_ini() {
+    local template_file="$1"
+    local output_file="$2"
+
+    python3 - "$template_file" "$output_file" <<'PY'
+import os
+import sys
+
+template_path, output_path = sys.argv[1], sys.argv[2]
+with open(template_path, "r", encoding="utf-8") as handle:
+    content = handle.read()
+
+replacements = {
+    "{{ hostid }}": os.environ["HOSTID"],
+    "{{ domain }}": os.environ["DOMAIN_VALUE"],
+    "{{ grafana.subpath }}": os.environ["GRAFANA_SUBPATH"],
+}
+for old, new in replacements.items():
+    content = content.replace(old, new)
+
+with open(output_path, "w", encoding="utf-8") as handle:
+    handle.write(content)
+PY
+}
+
+configure_grafana() {
+    local grafana_template
+
+    echo_info "Writing Grafana configuration..."
+
+    install -d -m 0755 /etc/grafana/provisioning/datasources
+    install -d -m 0755 /etc/grafana/provisioning/dashboards
+    install -d -m 0755 /var/lib/grafana/dashboards
+
+    grafana_template="$(mktemp)"
+    download_file "${ASSET_BASE_URL}/roles/telegraf_config/templates/grafana/grafana.ini" "$grafana_template" 0644
+    render_grafana_ini "$grafana_template" /etc/grafana/grafana.ini
+    rm -f "$grafana_template"
+
+    cat > /etc/grafana/provisioning/datasources/graf_ds.yaml <<EOF
+# config file version
+# Updated per https://grafana.com/docs/grafana/latest/datasources/influxdb/#provision-the-data-source
+apiVersion: 1
+
+deleteDatasources:
+  - name: Influxdb
+    orgId: 1
+
+datasources:
+  - name: Influxdb
+    type: influxdb
+    access: proxy
+    user: ${INFLUX_USERNAME}
+    url: http://localhost:8086
+    jsonData:
+      dbName: ${INFLUX_BUCKET}
+      httpMode: GET
+    secureJsonData:
+      password: ${INFLUX_PASSWORD}
+EOF
+
+    cat > /etc/grafana/provisioning/dashboards/graf_dash.yaml <<'EOF'
+apiVersion: 1
+
+providers:
+- name: 'LaunchPad Metrics'
+  orgId: 1
+  folder: ''
+  folderUid: ''
+  type: file
+  disableDeletion: false
+  editable: true
+  updateIntervalSeconds: 30
+  options:
+    path: /var/lib/grafana/dashboards
+EOF
+
+    download_file "${ASSET_BASE_URL}/roles/telegraf_config/templates/grafana/dashboard.json" /var/lib/grafana/dashboards/metrics.json 0644
+    chown -R grafana:grafana /var/lib/grafana/dashboards
+    systemctl_enable_restart grafana-server
+}
+
+collect_hardware_metadata() {
+    echo_info "Collecting hardware metadata..."
+
+    METADATA_PATH="$METADATA_PATH" python3 <<'PY'
+import glob
+import json
+import os
+import platform
+import shutil
+import socket
+import subprocess
+from pathlib import Path
+
+metadata_path = Path(os.environ.get("METADATA_PATH", "/etc/brev/metadata.json"))
+
+def run(command):
+    try:
+        return subprocess.check_output(command, shell=True, stderr=subprocess.DEVNULL, text=True).strip()
+    except Exception:
+        return ""
+
+def run_lines(command):
+    output = run(command)
+    return [line.strip() for line in output.splitlines() if line.strip()]
+
+def first_line(command):
+    lines = run_lines(command)
+    return lines[0] if lines else ""
+
+def int_value(value):
+    try:
+        return int(str(value).strip())
+    except Exception:
+        return 0
+
+def nvidia_query(field, join_lines=True):
+    output = run(f"nvidia-smi --query-gpu={field} --format=csv,noheader 2>/dev/null")
+    if not output:
+        return ""
+    lines = [line.strip() for line in output.splitlines() if line.strip()]
+    if not join_lines:
+        return lines[0] if lines else ""
+    return ",".join(lines)
+
+def cpu_model():
+    model = first_line("awk -F': ' '/model name/ {print $2; exit}' /proc/cpuinfo")
+    return model or platform.processor() or "Unknown"
+
+def meminfo_mb(key):
+    raw = first_line(f"awk '/^{key}:/ {{print $2; exit}}' /proc/meminfo")
+    return int_value(raw) // 1024
+
+def processor_count():
+    return int_value(run("grep -c '^physical id' /proc/cpuinfo")) or 1
+
+def processor_cores():
+    return int_value(first_line("awk -F': ' '/cpu cores/ {print $2; exit}' /proc/cpuinfo"))
+
+def processor_vcpus():
+    return os.cpu_count() or 0
+
+def threads_per_core():
+    cores = processor_cores()
+    vcpus = processor_vcpus()
+    return int(vcpus / cores) if cores and vcpus else 0
+
+def sysfs_first(paths, default="unknown"):
+    for path in paths:
+        try:
+            value = Path(path).read_text(encoding="utf-8", errors="ignore").strip()
+            if value:
+                return value
+        except Exception:
+            pass
+    return default
+
+def network_interfaces():
+    return sorted(Path(path).name for path in glob.glob("/sys/class/net/*"))
+
+def storage_devices():
+    devices = {}
+    for path in sorted(glob.glob("/sys/block/*")):
+        name = Path(path).name
+        if name.startswith(("loop", "ram")):
+            continue
+        size = int_value(sysfs_first([f"{path}/size"], "0"))
+        model = sysfs_first([f"{path}/device/model"], "")
+        rotational = sysfs_first([f"{path}/queue/rotational"], "")
+        devices[name] = {
+            "model": model,
+            "sectors": size,
+            "size_bytes": size * 512,
+            "rotational": rotational,
+        }
+    return devices
+
+lspci_gpu_count = int_value(run("lspci 2>/dev/null | grep -icE 'VGA|3D controller.*NVIDIA|Display.*NVIDIA'"))
+nvidia_gpu_count = int_value(nvidia_query("count", join_lines=False))
+amd_gpu_count = int_value(run("lspci 2>/dev/null | grep -icE 'VGA.*AMD|3D.*AMD|Display.*AMD'"))
+intel_gpu_count = int_value(run("lspci 2>/dev/null | grep -icE 'VGA.*Intel|Display.*Intel.*Graphics'"))
+total_gpu_count = (nvidia_gpu_count if nvidia_gpu_count > 0 else lspci_gpu_count) + amd_gpu_count + intel_gpu_count
+
+cuda_toolkit_version = run("nvcc --version 2>/dev/null | grep 'release' | sed 's/.*release \\([0-9.]*\\).*/\\1/' | tr -d '\\n'")
+cuda_runtime_version = run("ldconfig -p 2>/dev/null | grep -oP 'libcudart\\.so\\.\\K[0-9.]+' | head -1 | tr -d '\\n'")
+nvidia_driver_version = nvidia_query("driver_version", join_lines=False)
+nvidia_gpu_names = nvidia_query("name")
+nvidia_gpu_memory = nvidia_query("memory.total")
+nvidia_gpu_compute_cap = nvidia_query("compute_cap")
+
+hardware_metadata = {
+    "hardware_summary": {
+        "cpu_model": cpu_model(),
+        "total_cpus": processor_count(),
+        "total_cores": processor_cores(),
+        "total_vcpus": processor_vcpus(),
+        "total_memory_mb": meminfo_mb("MemTotal"),
+        "total_gpus": total_gpu_count,
+        "gpu_models": nvidia_gpu_names,
+        "nvidia_driver_version": nvidia_driver_version,
+        "cuda_toolkit_version": cuda_toolkit_version,
+        "cuda_runtime_version": cuda_runtime_version,
+        "gpu_memory_total_mb": nvidia_gpu_memory,
+        "gpu_compute_capabilities": nvidia_gpu_compute_cap,
+        "system_vendor": sysfs_first(["/sys/class/dmi/id/sys_vendor"], "Unknown"),
+        "system_model": sysfs_first(["/sys/class/dmi/id/product_name"], "Unknown"),
+    },
+    "hardware": {
+        "cpu": {
+            "architecture": platform.machine() or "unknown",
+            "processor_count": processor_count(),
+            "processor_cores": processor_cores(),
+            "processor_threads_per_core": threads_per_core(),
+            "processor_vcpus": processor_vcpus(),
+            "model_name": cpu_model(),
+        },
+        "memory": {
+            "total_mb": meminfo_mb("MemTotal"),
+            "free_mb": meminfo_mb("MemFree"),
+            "swap_total_mb": meminfo_mb("SwapTotal"),
+            "swap_free_mb": meminfo_mb("SwapFree"),
+        },
+        "motherboard": {
+            "manufacturer": sysfs_first(["/sys/class/dmi/id/board_vendor", "/sys/class/dmi/id/sys_vendor"], "unknown"),
+            "product_name": sysfs_first(["/sys/class/dmi/id/board_name", "/sys/class/dmi/id/product_name"], "unknown"),
+            "product_version": sysfs_first(["/sys/class/dmi/id/board_version", "/sys/class/dmi/id/product_version"], "unknown"),
+        },
+        "bios": {
+            "vendor": sysfs_first(["/sys/class/dmi/id/bios_version"], "unknown"),
+            "version": sysfs_first(["/sys/class/dmi/id/bios_version"], "unknown"),
+            "date": sysfs_first(["/sys/class/dmi/id/bios_date"], "unknown"),
+        },
+        "system": {
+            "vendor": sysfs_first(["/sys/class/dmi/id/sys_vendor"], "unknown"),
+            "product_name": sysfs_first(["/sys/class/dmi/id/product_name"], "unknown"),
+            "serial_number": sysfs_first(["/sys/class/dmi/id/product_serial"], "unknown"),
+            "uuid": sysfs_first(["/sys/class/dmi/id/product_uuid"], "unknown"),
+            "fqdn": socket.getfqdn(),
+        },
+        "gpu": {
+            "total_count": total_gpu_count,
+            "nvidia": {
+                "count": str(nvidia_gpu_count),
+                "driver_version": nvidia_driver_version,
+                "cuda_toolkit_version": cuda_toolkit_version,
+                "cuda_runtime_version": cuda_runtime_version,
+                "gpu_models": nvidia_gpu_names,
+                "serial_numbers": nvidia_query("serial"),
+                "uuids": nvidia_query("uuid"),
+                "memory_total_mb": nvidia_gpu_memory,
+                "compute_capabilities": nvidia_gpu_compute_cap,
+                "pci_bus_ids": nvidia_query("pci.bus_id"),
+                "persistence_mode": nvidia_query("persistence_mode", join_lines=False),
+                "compute_mode": nvidia_query("compute_mode", join_lines=False),
+            },
+            "amd": {"count": str(amd_gpu_count)},
+            "intel": {"count": str(intel_gpu_count)},
+        },
+        "network": {"interfaces": network_interfaces()},
+        "storage": {"devices": storage_devices()},
+    },
+}
+
+existing = {}
+if metadata_path.exists():
+    try:
+        existing = json.loads(metadata_path.read_text(encoding="utf-8"))
+    except Exception:
+        backup_path = metadata_path.with_suffix(metadata_path.suffix + ".invalid")
+        shutil.copy2(metadata_path, backup_path)
+
+def merge(a, b):
+    result = dict(a)
+    for key, value in b.items():
+        if isinstance(result.get(key), dict) and isinstance(value, dict):
+            result[key] = merge(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+metadata_path.parent.mkdir(parents=True, exist_ok=True)
+if metadata_path.exists():
+    shutil.copy2(metadata_path, str(metadata_path) + ".bak")
+metadata_path.write_text(json.dumps(merge(existing, hardware_metadata), indent=4, sort_keys=True) + "\n", encoding="utf-8")
+metadata_path.chmod(0o644)
+PY
+}
+
+install_fleet_package() {
+    local pkg_path="/opt/${FLEET_PKG_AMD64}"
+
+    echo_info "Installing fleet package..."
+    download_file "$FLEET_AMD64_URL" "$pkg_path" 0644
+    wait_for_apt_lock
+    if ! DEBIAN_FRONTEND=noninteractive apt-get install -y "$pkg_path"; then
+        echo_warn "Fleet package installation failed; continuing to match the non-failing Ansible role."
+    fi
+}
+
+main() {
+    require_root
+    parse_args "$@"
+    readonly HOSTID="$(detect_hostid)"
+    export HOSTID DOMAIN_VALUE GRAFANA_SUBPATH
+
+    echo_info "Using host id: ${HOSTID}"
+
+    install_base_packages
+    set_instance_hostname "$HOSTID"
+    collect_hardware_metadata || echo_warn "Hardware metadata collection failed; continuing."
+    configure_repositories
+    install_metrics_packages
+    configure_influxdb
+    configure_telegraf
+    configure_grafana
+    install_fleet_package
+
+    echo_info "Raw metrics collector setup completed successfully."
+}
+
+main "$@"

--- a/setup-raw.sh
+++ b/setup-raw.sh
@@ -89,12 +89,12 @@ wait_for_apt_lock() {
 
 apt_install() {
     wait_for_apt_lock
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "$@"
+    NEEDRESTART_SUSPEND=1 DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "$@"
 }
 
 apt_update() {
     wait_for_apt_lock
-    DEBIAN_FRONTEND=noninteractive apt-get update
+    NEEDRESTART_SUSPEND=1 DEBIAN_FRONTEND=noninteractive apt-get update
 }
 
 apt_package_installed() {
@@ -804,7 +804,7 @@ install_fleet_package() {
     echo_info "Installing fleet package..."
     download_file "$FLEET_AMD64_URL" "$pkg_path" 0644
     wait_for_apt_lock
-    if ! DEBIAN_FRONTEND=noninteractive apt-get install -y "$pkg_path"; then
+    if ! NEEDRESTART_SUSPEND=1 DEBIAN_FRONTEND=noninteractive apt-get install -y "$pkg_path"; then
         echo_warn "Fleet package installation failed; continuing to match the non-failing Ansible role."
     fi
 }

--- a/setup-raw.sh
+++ b/setup-raw.sh
@@ -33,6 +33,7 @@ INFLUX_ORG="${INFLUX_ORG:-lp}"
 INFLUX_PASSWORD="${INFLUX_PASSWORD:-LocaFluxCapacity2024}"
 INFLUX_USERNAME="${INFLUX_USERNAME:-lp}"
 METADATA_PATH="${METADATA_PATH:-/etc/brev/metadata.json}"
+METADATA_BACKUP="${METADATA_BACKUP:-${metadata_backup:-yes}}"
 SKIP_HOSTNAME_CONF=false
 # Failures are tolerated by default so parent bootstrap/orchestration scripts do
 # not fail closed if this metrics setup encounters an issue.
@@ -221,6 +222,17 @@ int_value() {
     fi
 }
 
+is_truthy() {
+    case "${1:-}" in
+        true|TRUE|True|yes|YES|Yes|y|Y|1)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
 sysfs_first() {
     local default="$1"
     shift
@@ -336,6 +348,10 @@ parse_args() {
             metadata_path=*|METADATA_PATH=*)
                 value="${arg#*=}"
                 METADATA_PATH="$value"
+                ;;
+            metadata_backup=*|METADATA_BACKUP=*)
+                value="${arg#*=}"
+                METADATA_BACKUP="$value"
                 ;;
             fleet_amd64_url=*|FLEET_AMD64_URL=*)
                 value="${arg#*=}"
@@ -860,7 +876,9 @@ collect_hardware_metadata() {
     existing_metadata="{}"
     if [[ -f "$METADATA_PATH" ]]; then
         if jq -e . "$METADATA_PATH" >/dev/null 2>&1; then
-            cp "$METADATA_PATH" "${METADATA_PATH}.bak"
+            if is_truthy "$METADATA_BACKUP"; then
+                cp "$METADATA_PATH" "${METADATA_PATH}.bak"
+            fi
             existing_metadata="$(cat "$METADATA_PATH")"
         else
             cp "$METADATA_PATH" "${METADATA_PATH}.invalid"

--- a/setup-raw.sh
+++ b/setup-raw.sh
@@ -166,6 +166,10 @@ apt_install_missing() {
     apt_install "${missing[@]}"
 }
 
+restore_tmp_permissions() {
+    chmod 1777 /tmp
+}
+
 download_file() {
     local url="$1"
     local dest="$2"
@@ -909,6 +913,7 @@ main() {
     configure_influxdb
     configure_telegraf
     configure_grafana
+    restore_tmp_permissions
 
     echo_info "Raw metrics collector setup completed successfully."
 }

--- a/setup-via-ansible.sh
+++ b/setup-via-ansible.sh
@@ -2,7 +2,9 @@
 
 set +x
 
-TOLERATE_FAILURES=false
+# Failures are tolerated by default so parent benchmark/orchestration scripts do
+# not fail closed if the Ansible setup path encounters an issue.
+TOLERATE_FAILURES=true
 
 # Function to display informational messages
 echo_info() {
@@ -17,9 +19,14 @@ parse_tolerance_flag() {
     local arg
 
     for arg in "$@"; do
-        if [ "$arg" = "--tolerate-failures" ]; then
-            TOLERATE_FAILURES=true
-        fi
+        case "$arg" in
+            --tolerate-failures)
+                TOLERATE_FAILURES=true
+                ;;
+            --strict-failures)
+                TOLERATE_FAILURES=false
+                ;;
+        esac
     done
 }
 
@@ -28,7 +35,7 @@ exit_or_tolerate() {
     local script_name="$2"
 
     if [ "$TOLERATE_FAILURES" = true ]; then
-        echo_warn "${script_name} failed with exit code ${status}; --tolerate-failures enabled, exiting 0."
+        echo_warn "${script_name} failed with exit code ${status}; failure tolerance enabled, exiting 0."
         exit 0
     fi
 
@@ -137,6 +144,9 @@ for arg in "$@"; do
             ;;
         --tolerate-failures)
             TOLERATE_FAILURES=true
+            ;;
+        --strict-failures)
+            TOLERATE_FAILURES=false
             ;;
         *)
             EXTRA_VARS_ARGS+=("$arg")

--- a/setup-via-ansible.sh
+++ b/setup-via-ansible.sh
@@ -43,6 +43,10 @@ exit_or_tolerate() {
     exit "$status"
 }
 
+restore_tmp_permissions() {
+    sudo chmod 1777 /tmp
+}
+
 run_main() {
     local status
 
@@ -179,8 +183,11 @@ ansible_status=$?
 set -e
 
 if [ "$ansible_status" -ne 0 ]; then
+    restore_tmp_permissions || true
     exit_or_tolerate "$ansible_status" "setup-via-ansible.sh"
 fi
+
+restore_tmp_permissions
 
 # Deactivate the virtual environment
 echo_info "Deactivating the virtual environment..."

--- a/setup-via-ansible.sh
+++ b/setup-via-ansible.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+set -Eeuo pipefail
 set +x
 
 # Failures are tolerated by default so parent benchmark/orchestration scripts do
@@ -34,12 +35,25 @@ exit_or_tolerate() {
     local status="$1"
     local script_name="$2"
 
-    if [ "$TOLERATE_FAILURES" = true ]; then
+    if [ "$status" -ne 0 ] && [ "$TOLERATE_FAILURES" = true ]; then
         echo_warn "${script_name} failed with exit code ${status}; failure tolerance enabled, exiting 0."
         exit 0
     fi
 
     exit "$status"
+}
+
+run_main() {
+    local status
+
+    set +e
+    (
+        set -Eeuo pipefail
+        main "$@"
+    )
+    status="$?"
+
+    exit_or_tolerate "$status" "setup-via-ansible.sh"
 }
 
 # Function to wait for apt lock to be free
@@ -64,7 +78,7 @@ wait_for_apt_lock() {
     echo_info "Apt lock is now free. Proceeding with package installation."
 }
 
-parse_tolerance_flag "$@"
+main() {
 
 # Update package lists and install prerequisites
 echo_info "Updating package lists and installing prerequisites..."
@@ -159,8 +173,10 @@ EXTRA_VARS_ARGS+=("skip_hostname_conf=$SKIP_HOSTNAME_CONF")
 
 # Run the Ansible playbook with logging and extra-vars
 echo_info "Running the Ansible playbook..."
+set +e
 ANSIBLE_LOG_PATH="$LOG_FILE" "$VENV_DIR/bin/ansible-playbook" -c local -i 'localhost,' -b playbook.yml --extra-vars "${EXTRA_VARS_ARGS[*]}"
 ansible_status=$?
+set -e
 
 if [ "$ansible_status" -ne 0 ]; then
     exit_or_tolerate "$ansible_status" "setup-via-ansible.sh"
@@ -171,6 +187,10 @@ echo_info "Deactivating the virtual environment..."
 deactivate
 
 echo_info "Ansible playbook execution completed successfully."
+}
+
+parse_tolerance_flag "$@"
+run_main "$@"
 
 # Sample call:
 # curl -sSL https://raw.githubusercontent.com/Shiftius/ansible-gpu-metrics-collector/main/setup-via-ansible.sh | bash -s -- aws_timestream_access_key='' aws_timestream_secret_key='' aws_timestream_database='' environmentID=''

--- a/setup-via-ansible.sh
+++ b/setup-via-ansible.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+set +x
+
+# Function to display informational messages
+echo_info() {
+    echo -e "\033[1;34m[INFO]\033[0m $1"
+}
+
+# Function to wait for apt lock to be free
+wait_for_apt_lock() {
+    local lock_file="/var/lib/dpkg/lock-frontend"
+    local lock_wait_time=360  # Maximum wait time in seconds
+    local interval=5          # Interval between checks in seconds
+    local elapsed=0
+
+    echo_info "Waiting for apt lock to be released..."
+
+    while sudo fuser "$lock_file" >/dev/null 2>&1; do
+        if [ "$elapsed" -ge "$lock_wait_time" ]; then
+            echo -e "\033[1;31m[ERROR]\033[0m Timeout waiting for apt lock to be released."
+            exit 1
+        fi
+        echo_info "Apt lock is currently held by another process. Waiting..."
+        sleep "$interval"
+        elapsed=$((elapsed + interval))
+    done
+
+    echo_info "Apt lock is now free. Proceeding with package installation."
+}
+
+# Update package lists and install prerequisites
+echo_info "Updating package lists and installing prerequisites..."
+
+# Wait for any existing apt processes to finish
+wait_for_apt_lock
+
+# Proceed with package installation
+sudo apt-get update
+sudo apt-get install -y python3 python3-pip python3-venv git
+
+# Define virtual environment directory
+VENV_DIR="/tmp/ansible_env"
+
+# Create virtual environment if it doesn't exist
+if [ ! -d "$VENV_DIR" ]; then
+    echo_info "Creating Python virtual environment at $VENV_DIR..."
+    python3 -m venv $VENV_DIR
+else
+    echo_info "Python virtual environment already exists at $VENV_DIR."
+fi
+
+# Activate the virtual environment
+echo_info "Activating the virtual environment..."
+source "$VENV_DIR/bin/activate"
+
+# Upgrade pip within the virtual environment
+echo_info "Upgrading pip..."
+pip install --upgrade pip
+
+# Install Ansible within the virtual environment
+echo_info "Installing Ansible in the virtual environment..."
+pip install ansible
+
+# Clone the Ansible repository
+REPO_URL="https://github.com/Shiftius/ansible-gpu-metrics-collector.git"
+CLONE_DIR="/tmp/mc"
+
+if [ ! -d "$CLONE_DIR" ]; then
+    echo_info "Cloning repository from $REPO_URL to $CLONE_DIR..."
+    git clone "$REPO_URL" "$CLONE_DIR"
+else
+    echo_info "Repository already cloned at $CLONE_DIR."
+fi
+
+cd "$CLONE_DIR"
+
+# Define log directory and file
+LOG_DIR="/var/log/ansible"
+LOG_FILE="$LOG_DIR/ansible-playbook.log"
+
+# Create the log directory with appropriate permissions
+echo_info "Setting up log directory at $LOG_DIR..."
+sudo mkdir -p "$LOG_DIR"
+sudo chmod 775 "$LOG_DIR"
+# Optional: Change ownership to the current user to allow writing without sudo
+# sudo chown "$USER":"$USER" "$LOG_DIR"
+
+# Create the log file with appropriate permissions
+echo_info "Creating log file at $LOG_FILE..."
+sudo touch "$LOG_FILE"
+# Secure the log file by setting appropriate permissions
+sudo chmod 664 "$LOG_FILE"
+# Optional: Change ownership to the current user to allow writing without sudo
+# sudo chown "$USER":"$USER" "$LOG_FILE"
+
+set +x  # Disable debug output to hide sensitive variables
+
+# Parse optional CLI flags while preserving existing extra-var passthrough behavior.
+SKIP_HOSTNAME_CONF=false
+EXTRA_VARS_ARGS=()
+
+for arg in "$@"; do
+    case "$arg" in
+        --skip-hostname-conf)
+            SKIP_HOSTNAME_CONF=true
+            ;;
+        *)
+            EXTRA_VARS_ARGS+=("$arg")
+            ;;
+    esac
+done
+
+# Capture script arguments to pass to Ansible as extra-vars.
+EXTRA_VARS_ARGS+=("skip_hostname_conf=$SKIP_HOSTNAME_CONF")
+
+# Run the Ansible playbook with logging and extra-vars
+echo_info "Running the Ansible playbook..."
+ANSIBLE_LOG_PATH="$LOG_FILE" "$VENV_DIR/bin/ansible-playbook" -c local -i 'localhost,' -b playbook.yml --extra-vars "${EXTRA_VARS_ARGS[*]}"
+
+# Deactivate the virtual environment
+echo_info "Deactivating the virtual environment..."
+deactivate
+
+echo_info "Ansible playbook execution completed successfully."
+
+# Sample call:
+# curl -sSL https://raw.githubusercontent.com/Shiftius/ansible-gpu-metrics-collector/main/setup-via-ansible.sh | bash -s -- aws_timestream_access_key='' aws_timestream_secret_key='' aws_timestream_database='' environmentID=''
+# Add --skip-hostname-conf to preserve the current hostname.

--- a/setup-via-ansible.sh
+++ b/setup-via-ansible.sh
@@ -2,9 +2,37 @@
 
 set +x
 
+TOLERATE_FAILURES=false
+
 # Function to display informational messages
 echo_info() {
     echo -e "\033[1;34m[INFO]\033[0m $1"
+}
+
+echo_warn() {
+    echo -e "\033[1;33m[WARN]\033[0m $1" >&2
+}
+
+parse_tolerance_flag() {
+    local arg
+
+    for arg in "$@"; do
+        if [ "$arg" = "--tolerate-failures" ]; then
+            TOLERATE_FAILURES=true
+        fi
+    done
+}
+
+exit_or_tolerate() {
+    local status="$1"
+    local script_name="$2"
+
+    if [ "$TOLERATE_FAILURES" = true ]; then
+        echo_warn "${script_name} failed with exit code ${status}; --tolerate-failures enabled, exiting 0."
+        exit 0
+    fi
+
+    exit "$status"
 }
 
 # Function to wait for apt lock to be free
@@ -19,7 +47,7 @@ wait_for_apt_lock() {
     while sudo fuser "$lock_file" >/dev/null 2>&1; do
         if [ "$elapsed" -ge "$lock_wait_time" ]; then
             echo -e "\033[1;31m[ERROR]\033[0m Timeout waiting for apt lock to be released."
-            exit 1
+            exit_or_tolerate 1 "setup-via-ansible.sh"
         fi
         echo_info "Apt lock is currently held by another process. Waiting..."
         sleep "$interval"
@@ -28,6 +56,8 @@ wait_for_apt_lock() {
 
     echo_info "Apt lock is now free. Proceeding with package installation."
 }
+
+parse_tolerance_flag "$@"
 
 # Update package lists and install prerequisites
 echo_info "Updating package lists and installing prerequisites..."
@@ -105,6 +135,9 @@ for arg in "$@"; do
         --skip-hostname-conf)
             SKIP_HOSTNAME_CONF=true
             ;;
+        --tolerate-failures)
+            TOLERATE_FAILURES=true
+            ;;
         *)
             EXTRA_VARS_ARGS+=("$arg")
             ;;
@@ -117,6 +150,11 @@ EXTRA_VARS_ARGS+=("skip_hostname_conf=$SKIP_HOSTNAME_CONF")
 # Run the Ansible playbook with logging and extra-vars
 echo_info "Running the Ansible playbook..."
 ANSIBLE_LOG_PATH="$LOG_FILE" "$VENV_DIR/bin/ansible-playbook" -c local -i 'localhost,' -b playbook.yml --extra-vars "${EXTRA_VARS_ARGS[*]}"
+ansible_status=$?
+
+if [ "$ansible_status" -ne 0 ]; then
+    exit_or_tolerate "$ansible_status" "setup-via-ansible.sh"
+fi
 
 # Deactivate the virtual environment
 echo_info "Deactivating the virtual environment..."

--- a/setup.sh
+++ b/setup.sh
@@ -13,13 +13,54 @@ export HISTFILE=/dev/null
 readonly DEFAULT_RAW_INSTALLER_URL="https://raw.githubusercontent.com/Shiftius/ansible-gpu-metrics-collector/${INSTALLER_REF:-main}/setup-raw.sh"
 
 RAW_INSTALLER_URL="${RAW_INSTALLER_URL:-$DEFAULT_RAW_INSTALLER_URL}"
+TOLERATE_FAILURES=false
 
 echo_info() {
     printf '\033[1;34m[INFO]\033[0m %s\n' "$*"
 }
 
+echo_warn() {
+    printf '\033[1;33m[WARN]\033[0m %s\n' "$*" >&2
+}
+
 echo_error() {
     printf '\033[1;31m[ERROR]\033[0m %s\n' "$*" >&2
+}
+
+exit_with_status() {
+    local status="$1"
+
+    if [[ "$status" -ne 0 && "$TOLERATE_FAILURES" == true ]]; then
+        echo_warn "setup.sh failed with exit code ${status}; --tolerate-failures enabled, exiting 0."
+        exit 0
+    fi
+
+    exit "$status"
+}
+
+parse_wrapper_args() {
+    local arg
+
+    for arg in "$@"; do
+        case "$arg" in
+            --tolerate-failures)
+                TOLERATE_FAILURES=true
+                ;;
+        esac
+    done
+}
+
+run_main() {
+    local status
+
+    set +e
+    (
+        set -Eeuo pipefail
+        main "$@"
+    )
+    status="$?"
+
+    exit_with_status "$status"
 }
 
 run_as_root() {
@@ -56,7 +97,7 @@ download_raw_installer() {
         wget -qO "$dest" "$RAW_INSTALLER_URL"
     else
         echo_error "Install curl or wget, or run setup.sh from a checkout that also contains setup-raw.sh."
-        exit 1
+        return 1
     fi
 
     chmod 0755 "$dest"
@@ -89,7 +130,8 @@ main() {
     echo_info "Setup completed successfully via setup-raw.sh."
 }
 
-main "$@"
+parse_wrapper_args "$@"
+run_main "$@"
 
 # Sample call:
 # curl -sSL https://raw.githubusercontent.com/Shiftius/ansible-gpu-metrics-collector/main/setup.sh | bash -s -- aws_timestream_access_key='' aws_timestream_secret_key='' aws_timestream_database='' environmentID=''

--- a/setup.sh
+++ b/setup.sh
@@ -2,7 +2,7 @@
 
 if [[ ${-} == *x* ]]; then
     echo "[ERROR] Do not run this script with shell tracing enabled; it can expose credentials." >&2
-    exit 1
+    exit 0
 fi
 
 set -Eeuo pipefail

--- a/setup.sh
+++ b/setup.sh
@@ -65,11 +65,14 @@ download_raw_installer() {
 main() {
     local raw_installer=""
     local downloaded_installer=""
+    local script_dir=""
 
     echo_info "Delegating setup to the raw shell installer..."
 
     if raw_installer="$(local_raw_installer)"; then
         echo_info "Using local setup-raw.sh."
+        script_dir="$(cd "$(dirname "$raw_installer")" && pwd)"
+        export ASSET_DIR="${ASSET_DIR:-$script_dir}"
     else
         downloaded_installer="$(mktemp)"
         echo_info "Downloading setup-raw.sh from ${RAW_INSTALLER_URL}..."

--- a/setup.sh
+++ b/setup.sh
@@ -13,7 +13,9 @@ export HISTFILE=/dev/null
 readonly DEFAULT_RAW_INSTALLER_URL="https://raw.githubusercontent.com/Shiftius/ansible-gpu-metrics-collector/${INSTALLER_REF:-main}/setup-raw.sh"
 
 RAW_INSTALLER_URL="${RAW_INSTALLER_URL:-$DEFAULT_RAW_INSTALLER_URL}"
-TOLERATE_FAILURES=false
+# Failures are tolerated by default so parent bootstrap/orchestration scripts do
+# not fail closed if this metrics setup encounters an issue.
+TOLERATE_FAILURES=true
 
 echo_info() {
     printf '\033[1;34m[INFO]\033[0m %s\n' "$*"
@@ -31,7 +33,7 @@ exit_with_status() {
     local status="$1"
 
     if [[ "$status" -ne 0 && "$TOLERATE_FAILURES" == true ]]; then
-        echo_warn "setup.sh failed with exit code ${status}; --tolerate-failures enabled, exiting 0."
+        echo_warn "setup.sh failed with exit code ${status}; failure tolerance enabled, exiting 0."
         exit 0
     fi
 
@@ -45,6 +47,9 @@ parse_wrapper_args() {
         case "$arg" in
             --tolerate-failures)
                 TOLERATE_FAILURES=true
+                ;;
+            --strict-failures)
+                TOLERATE_FAILURES=false
                 ;;
         esac
     done
@@ -127,7 +132,7 @@ main() {
         rm -f "$downloaded_installer"
     fi
 
-    echo_info "Setup completed successfully via setup-raw.sh."
+    echo_info "Setup invocation finished via setup-raw.sh."
 }
 
 parse_wrapper_args "$@"

--- a/setup.sh
+++ b/setup.sh
@@ -1,128 +1,92 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
+if [[ ${-} == *x* ]]; then
+    echo "[ERROR] Do not run this script with shell tracing enabled; it can expose credentials." >&2
+    exit 1
+fi
+
+set -Eeuo pipefail
 set +x
 
-# Function to display informational messages
+export HISTFILE=/dev/null
+
+readonly DEFAULT_RAW_INSTALLER_URL="https://raw.githubusercontent.com/Shiftius/ansible-gpu-metrics-collector/${INSTALLER_REF:-main}/setup-raw.sh"
+
+RAW_INSTALLER_URL="${RAW_INSTALLER_URL:-$DEFAULT_RAW_INSTALLER_URL}"
+
 echo_info() {
-    echo -e "\033[1;34m[INFO]\033[0m $1"
+    printf '\033[1;34m[INFO]\033[0m %s\n' "$*"
 }
 
-# Function to wait for apt lock to be free
-wait_for_apt_lock() {
-    local lock_file="/var/lib/dpkg/lock-frontend"
-    local lock_wait_time=360  # Maximum wait time in seconds
-    local interval=5          # Interval between checks in seconds
-    local elapsed=0
-
-    echo_info "Waiting for apt lock to be released..."
-
-    while sudo fuser "$lock_file" >/dev/null 2>&1; do
-        if [ "$elapsed" -ge "$lock_wait_time" ]; then
-            echo -e "\033[1;31m[ERROR]\033[0m Timeout waiting for apt lock to be released."
-            exit 1
-        fi
-        echo_info "Apt lock is currently held by another process. Waiting..."
-        sleep "$interval"
-        elapsed=$((elapsed + interval))
-    done
-
-    echo_info "Apt lock is now free. Proceeding with package installation."
+echo_error() {
+    printf '\033[1;31m[ERROR]\033[0m %s\n' "$*" >&2
 }
 
-# Update package lists and install prerequisites
-echo_info "Updating package lists and installing prerequisites..."
+run_as_root() {
+    if [[ "$(id -u)" -eq 0 ]]; then
+        bash "$@"
+    else
+        sudo -E bash "$@"
+    fi
+}
 
-# Wait for any existing apt processes to finish
-wait_for_apt_lock
+local_raw_installer() {
+    local source_path="${BASH_SOURCE[0]:-}"
+    local script_dir
 
-# Proceed with package installation
-sudo apt-get update
-sudo apt-get install -y python3 python3-pip python3-venv git
+    if [[ -z "$source_path" || "$source_path" == "bash" || "$source_path" == */bash ]]; then
+        return 1
+    fi
 
-# Define virtual environment directory
-VENV_DIR="/tmp/ansible_env"
+    script_dir="$(cd "$(dirname "$source_path")" && pwd)"
+    if [[ -f "${script_dir}/setup-raw.sh" ]]; then
+        printf '%s\n' "${script_dir}/setup-raw.sh"
+        return 0
+    fi
 
-# Create virtual environment if it doesn't exist
-if [ ! -d "$VENV_DIR" ]; then
-    echo_info "Creating Python virtual environment at $VENV_DIR..."
-    python3 -m venv $VENV_DIR
-else
-    echo_info "Python virtual environment already exists at $VENV_DIR."
-fi
+    return 1
+}
 
-# Activate the virtual environment
-echo_info "Activating the virtual environment..."
-source "$VENV_DIR/bin/activate"
+download_raw_installer() {
+    local dest="$1"
 
-# Upgrade pip within the virtual environment
-echo_info "Upgrading pip..."
-pip install --upgrade pip
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL "$RAW_INSTALLER_URL" -o "$dest"
+    elif command -v wget >/dev/null 2>&1; then
+        wget -qO "$dest" "$RAW_INSTALLER_URL"
+    else
+        echo_error "Install curl or wget, or run setup.sh from a checkout that also contains setup-raw.sh."
+        exit 1
+    fi
 
-# Install Ansible within the virtual environment
-echo_info "Installing Ansible in the virtual environment..."
-pip install ansible
+    chmod 0755 "$dest"
+}
 
-# Clone the Ansible repository
-REPO_URL="https://github.com/Shiftius/ansible-gpu-metrics-collector.git"
-CLONE_DIR="/tmp/mc"
+main() {
+    local raw_installer=""
+    local downloaded_installer=""
 
-if [ ! -d "$CLONE_DIR" ]; then
-    echo_info "Cloning repository from $REPO_URL to $CLONE_DIR..."
-    git clone "$REPO_URL" "$CLONE_DIR"
-else
-    echo_info "Repository already cloned at $CLONE_DIR."
-fi
+    echo_info "Delegating setup to the raw shell installer..."
 
-cd "$CLONE_DIR"
+    if raw_installer="$(local_raw_installer)"; then
+        echo_info "Using local setup-raw.sh."
+    else
+        downloaded_installer="$(mktemp)"
+        echo_info "Downloading setup-raw.sh from ${RAW_INSTALLER_URL}..."
+        download_raw_installer "$downloaded_installer"
+        raw_installer="$downloaded_installer"
+    fi
 
-# Define log directory and file
-LOG_DIR="/var/log/ansible"
-LOG_FILE="$LOG_DIR/ansible-playbook.log"
+    run_as_root "$raw_installer" "$@"
 
-# Create the log directory with appropriate permissions
-echo_info "Setting up log directory at $LOG_DIR..."
-sudo mkdir -p "$LOG_DIR"
-sudo chmod 775 "$LOG_DIR"
-# Optional: Change ownership to the current user to allow writing without sudo
-# sudo chown "$USER":"$USER" "$LOG_DIR"
+    if [[ -n "$downloaded_installer" ]]; then
+        rm -f "$downloaded_installer"
+    fi
 
-# Create the log file with appropriate permissions
-echo_info "Creating log file at $LOG_FILE..."
-sudo touch "$LOG_FILE"
-# Secure the log file by setting appropriate permissions
-sudo chmod 664 "$LOG_FILE"
-# Optional: Change ownership to the current user to allow writing without sudo
-# sudo chown "$USER":"$USER" "$LOG_FILE"
+    echo_info "Setup completed successfully via setup-raw.sh."
+}
 
-set +x  # Disable debug output to hide sensitive variables
-
-# Parse optional CLI flags while preserving existing extra-var passthrough behavior.
-SKIP_HOSTNAME_CONF=false
-EXTRA_VARS_ARGS=()
-
-for arg in "$@"; do
-    case "$arg" in
-        --skip-hostname-conf)
-            SKIP_HOSTNAME_CONF=true
-            ;;
-        *)
-            EXTRA_VARS_ARGS+=("$arg")
-            ;;
-    esac
-done
-
-# Capture script arguments to pass to Ansible as extra-vars.
-EXTRA_VARS_ARGS+=("skip_hostname_conf=$SKIP_HOSTNAME_CONF")
-
-# Run the Ansible playbook with logging and extra-vars
-echo_info "Running the Ansible playbook..."
-ANSIBLE_LOG_PATH="$LOG_FILE" "$VENV_DIR/bin/ansible-playbook" -c local -i 'localhost,' -b playbook.yml --extra-vars "${EXTRA_VARS_ARGS[*]}"
-
-# Deactivate the virtual environment
-echo_info "Deactivating the virtual environment..."
-deactivate
-
-echo_info "Ansible playbook execution completed successfully."
+main "$@"
 
 # Sample call:
 # curl -sSL https://raw.githubusercontent.com/Shiftius/ansible-gpu-metrics-collector/main/setup.sh | bash -s -- aws_timestream_access_key='' aws_timestream_secret_key='' aws_timestream_database='' environmentID=''


### PR DESCRIPTION
## What changed

- Add a raw shell setup path and make `setup.sh` delegate to it by default.
- Preserve the original Ansible bootstrap as `setup-via-ansible.sh` for benchmark comparison.
- Add `reset-setup.sh` to clean package/config/data/cache state between runs.
- Remove Python, pip, venv, and Ansible from the default fast path.
- Generate metadata with shell probes plus `jq` and render Grafana config with `sed`.
- Use local Grafana assets from the checkout when available, falling back to raw HTTP asset fetches.
- Install Grafana, InfluxDB, Telegraf, and the Fleet deb in one apt transaction.
- Harden reset for broken `influxdb2` removal, Fleet package cleanup, Influx CLI state, `/tmp` permissions, and `needrestart` overhead.

## Benchmark results

Test instance: `blushing-brown-woodpecker` / `brev-1wli3f4bp`.

| Script | Purpose | Total execution time | Result |
|---|---|---:|---|
| `setup.sh` | Optimized raw shell setup | `40.71s` | Passed |
| `setup-via-ansible.sh` | Original Ansible bootstrap path | `104.49s` | Passed |
| `reset-setup.sh --purge-benchmark-cache` | Clean state between benchmark runs | `11.00s` to `16.05s` observed | Passed |

The optimized raw setup is about `2.57x` faster than the Ansible bootstrap on the benchmark instance.

## Validation

- `bash -n setup.sh setup-raw.sh reset-setup.sh setup-via-ansible.sh`
- `git diff --check`
- Metadata JSON smoke test for `setup-raw.sh`
- Grafana template substitution smoke test for `setup-raw.sh`
- Live benchmark validation on `blushing-brown-woodpecker`:
  - `influxdb`, `telegraf`, `grafana-server`, and `orbit` active
  - `grafana`, `telegraf`, `influxdb2`, `influxdb2-cli`, and `fleet-osquery` installed
  - `/etc/brev/metadata.json` present and valid
  - InfluxDB `lp` bucket exists
  - Grafana `/metrics/login` returns HTTP `200` on port `13000`
  - `/etc/telegraf/telegraf.conf` exists and is non-empty

## Merge note

- Please use squash merge for this PR.
