### PR TITLE
Add Fleet-only setup mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ status output, but normalize failures to exit code `0`. Use `--strict-failures` 
 benchmark/debug run to exit nonzero on failure. `--tolerate-failures` is still accepted to explicitly request
 the default behavior.
 
+Use `--fleet-only` when an instance needs Fleet enrollment without the InfluxDB, Telegraf, and Grafana
+metrics stack or its package repositories:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/Shiftius/ansible-gpu-metrics-collector/main/setup.sh | \
+  bash -s -- --fleet-only --skip-hostname-conf --strict-failures
+```
+
+In the default tolerant mode, a Fleet download or installation failure is logged and the command exits
+successfully. With `--strict-failures`, the same failure returns a nonzero exit code.
+
 The raw installer also accepts environment variables, which keeps secrets out of the process arguments:
 
 ```bash

--- a/setup-raw.sh
+++ b/setup-raw.sh
@@ -34,6 +34,7 @@ INFLUX_PASSWORD="${INFLUX_PASSWORD:-LocaFluxCapacity2024}"
 INFLUX_USERNAME="${INFLUX_USERNAME:-lp}"
 METADATA_PATH="${METADATA_PATH:-/etc/brev/metadata.json}"
 METADATA_BACKUP="${METADATA_BACKUP:-${metadata_backup:-yes}}"
+FLEET_ONLY=false
 SKIP_HOSTNAME_CONF=false
 # Failures are tolerated by default so parent bootstrap/orchestration scripts do
 # not fail closed if this metrics setup encounters an issue.
@@ -277,6 +278,9 @@ parse_args() {
 
     for arg in "$@"; do
         case "$arg" in
+            --fleet-only)
+                FLEET_ONLY=true
+                ;;
             --skip-hostname-conf)
                 SKIP_HOSTNAME_CONF=true
                 ;;
@@ -404,7 +408,11 @@ install_base_packages() {
     fi
 
     echo_info "Installing base packages..."
-    apt_install_missing ca-certificates curl dmidecode gnupg jq lshw pciutils wget
+    if [[ "$FLEET_ONLY" == true ]]; then
+        apt_install_missing ca-certificates curl
+    else
+        apt_install_missing ca-certificates curl dmidecode gnupg jq lshw pciutils wget
+    fi
 }
 
 configure_repositories() {
@@ -439,15 +447,59 @@ configure_repositories() {
     apt_update
 }
 
+handle_fleet_install_failure() {
+    local message="$1"
+
+    if [[ "$TOLERATE_FAILURES" == true ]]; then
+        echo_warn "${message}; failure tolerance enabled, continuing without Fleet."
+        return 0
+    fi
+
+    echo_error "$message"
+    return 1
+}
+
+install_fleet_package() {
+    local pkg_path="/opt/${FLEET_PKG_AMD64}"
+
+    echo_info "Installing Fleet package..."
+    rm -f "$pkg_path"
+    if ! download_file "$FLEET_AMD64_URL" "$pkg_path" 0644; then
+        handle_fleet_install_failure "Fleet package download failed"
+        return
+    fi
+
+    if ! apt_install "$pkg_path"; then
+        handle_fleet_install_failure "Fleet package installation failed"
+    fi
+}
+
 install_metrics_packages() {
     local pkg_path="/opt/${FLEET_PKG_AMD64}"
 
     echo_info "Installing metrics packages..."
-    download_file "$FLEET_AMD64_URL" "$pkg_path" 0644
-    if ! apt_install grafana influxdb2 influxdb2-cli telegraf "$pkg_path"; then
-        echo_warn "Combined metrics and fleet package install failed; retrying metrics packages without fleet."
+    if ! download_file "$FLEET_AMD64_URL" "$pkg_path" 0644; then
+        if [[ "$TOLERATE_FAILURES" == false ]]; then
+            echo_error "Fleet package download failed."
+            return 1
+        fi
+
+        echo_warn "Fleet package download failed; installing metrics packages without Fleet."
         apt_install grafana influxdb2 influxdb2-cli telegraf
+        return
     fi
+
+    if apt_install grafana influxdb2 influxdb2-cli telegraf "$pkg_path"; then
+        return
+    fi
+
+    if [[ "$TOLERATE_FAILURES" == false ]]; then
+        echo_error "Combined metrics and Fleet package installation failed."
+        return 1
+    fi
+
+    echo_warn "Combined metrics and Fleet package install failed; retrying metrics packages without Fleet."
+    apt_install grafana influxdb2 influxdb2-cli telegraf
 }
 
 systemctl_enable_restart() {
@@ -907,6 +959,14 @@ main() {
 
     install_base_packages
     set_instance_hostname "$HOSTID"
+
+    if [[ "$FLEET_ONLY" == true ]]; then
+        install_fleet_package
+        restore_tmp_permissions
+        echo_info "Fleet-only setup completed successfully."
+        return
+    fi
+
     collect_hardware_metadata || echo_warn "Hardware metadata collection failed; continuing."
     configure_repositories
     install_metrics_packages

--- a/tests/test-setup-raw.sh
+++ b/tests/test-setup-raw.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+library_copy="$(mktemp)"
+test_fleet_package="/tmp/setup-raw-test-fleet-$$.deb"
+trap 'rm -f "$library_copy" "$test_fleet_package"' EXIT
+
+sed '/^parse_tolerance_flag "\$@"/,$d' "${repo_root}/setup-raw.sh" > "$library_copy"
+# shellcheck source=/dev/null
+source "$library_copy"
+FLEET_PKG_AMD64="../tmp/$(basename "$test_fleet_package")"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+test_fleet_failure_is_tolerated_by_default() {
+    (
+        TOLERATE_FAILURES=true
+        download_file() { return 1; }
+
+        install_fleet_package || fail "default mode rejected a Fleet download failure"
+    )
+}
+
+test_fleet_failure_is_strict_when_requested() {
+    (
+        TOLERATE_FAILURES=false
+        download_file() { return 1; }
+
+        if install_fleet_package; then
+            fail "strict mode tolerated a Fleet download failure"
+        fi
+    )
+}
+
+test_fleet_install_failure_respects_tolerance_mode() {
+    (
+        download_file() { return 0; }
+        apt_install() { return 1; }
+
+        TOLERATE_FAILURES=true
+        install_fleet_package || fail "default mode rejected a Fleet installation failure"
+
+        TOLERATE_FAILURES=false
+        if install_fleet_package; then
+            fail "strict mode tolerated a Fleet installation failure"
+        fi
+    )
+}
+
+test_default_setup_keeps_combined_package_transaction() {
+    local trace
+    trace="$(mktemp)"
+
+    (
+        TOLERATE_FAILURES=true
+        download_file() { :; }
+        apt_install() { printf '%s\n' "$*" >> "$trace"; }
+
+        install_metrics_packages
+    )
+
+    [[ "$(wc -l < "$trace" | tr -d ' ')" == "1" ]] \
+        || fail "Default setup used more than one apt transaction"
+    grep -q "grafana influxdb2 influxdb2-cli telegraf /opt/" "$trace" \
+        || fail "Default apt transaction did not include both metrics and Fleet"
+    rm -f "$trace"
+}
+
+test_combined_install_failure_respects_tolerance_mode() {
+    local trace
+    trace="$(mktemp)"
+
+    (
+        TOLERATE_FAILURES=true
+        download_file() { :; }
+        apt_install() {
+            printf '%s\n' "$*" >> "$trace"
+            [[ "$(wc -l < "$trace" | tr -d ' ')" -gt 1 ]]
+        }
+
+        install_metrics_packages
+    ) || fail "Default mode did not preserve the metrics-only fallback"
+
+    [[ "$(wc -l < "$trace" | tr -d ' ')" == "2" ]] \
+        || fail "Default fallback did not use exactly two apt attempts"
+    [[ "$(tail -n 1 "$trace")" == "grafana influxdb2 influxdb2-cli telegraf" ]] \
+        || fail "Default fallback did not retry metrics packages without Fleet"
+
+    : > "$trace"
+    (
+        TOLERATE_FAILURES=false
+        download_file() { :; }
+        apt_install() {
+            printf '%s\n' "$*" >> "$trace"
+            return 1
+        }
+
+        if install_metrics_packages; then
+            fail "Strict mode tolerated a combined package installation failure"
+        fi
+    )
+
+    [[ "$(wc -l < "$trace" | tr -d ' ')" == "1" ]] \
+        || fail "Strict mode retried without Fleet"
+    rm -f "$trace"
+}
+
+test_full_setup_fleet_download_failure_respects_tolerance_mode() {
+    local trace
+    trace="$(mktemp)"
+
+    (
+        TOLERATE_FAILURES=true
+        download_file() { return 1; }
+        apt_install() { printf '%s\n' "$*" >> "$trace"; }
+
+        install_metrics_packages
+    ) || fail "Default mode rejected a Fleet download failure"
+
+    [[ "$(cat "$trace")" == "grafana influxdb2 influxdb2-cli telegraf" ]] \
+        || fail "Default mode did not continue with metrics packages after Fleet download failed"
+
+    : > "$trace"
+    (
+        TOLERATE_FAILURES=false
+        download_file() { return 1; }
+        apt_install() { printf '%s\n' "$*" >> "$trace"; }
+
+        if install_metrics_packages; then
+            fail "Strict mode tolerated a Fleet download failure"
+        fi
+    )
+
+    [[ ! -s "$trace" ]] || fail "Strict mode installed metrics packages after Fleet download failed"
+    rm -f "$trace"
+}
+
+test_fleet_only_skips_metrics_stack() {
+    local trace
+    trace="$(mktemp)"
+
+    (
+        require_root() { :; }
+        detect_hostid() { printf 'test-host'; }
+        install_base_packages() { echo base >> "$trace"; }
+        set_instance_hostname() { echo hostname >> "$trace"; }
+        install_fleet_package() { echo fleet >> "$trace"; }
+        collect_hardware_metadata() { echo metadata >> "$trace"; }
+        configure_repositories() { echo repositories >> "$trace"; }
+        install_metrics_packages() { echo metrics >> "$trace"; }
+        configure_influxdb() { echo influxdb >> "$trace"; }
+        configure_telegraf() { echo telegraf >> "$trace"; }
+        configure_grafana() { echo grafana >> "$trace"; }
+        restore_tmp_permissions() { echo tmp >> "$trace"; }
+
+        main --fleet-only --skip-hostname-conf
+    )
+
+    [[ "$(cat "$trace")" == $'base\nhostname\nfleet\ntmp' ]] \
+        || fail "Fleet-only mode invoked unexpected setup steps: $(tr '\n' ' ' < "$trace")"
+    rm -f "$trace"
+}
+
+test_full_setup_retains_metrics_stack() {
+    local trace
+    trace="$(mktemp)"
+
+    (
+        require_root() { :; }
+        detect_hostid() { printf 'test-host'; }
+        install_base_packages() { echo base >> "$trace"; }
+        set_instance_hostname() { echo hostname >> "$trace"; }
+        collect_hardware_metadata() { echo metadata >> "$trace"; }
+        configure_repositories() { echo repositories >> "$trace"; }
+        install_metrics_packages() { echo metrics >> "$trace"; }
+        configure_influxdb() { echo influxdb >> "$trace"; }
+        configure_telegraf() { echo telegraf >> "$trace"; }
+        configure_grafana() { echo grafana >> "$trace"; }
+        restore_tmp_permissions() { echo tmp >> "$trace"; }
+
+        main
+    )
+
+    [[ "$(cat "$trace")" == $'base\nhostname\nmetadata\nrepositories\nmetrics\ninfluxdb\ntelegraf\ngrafana\ntmp' ]] \
+        || fail "Full setup omitted or reordered required steps: $(tr '\n' ' ' < "$trace")"
+    rm -f "$trace"
+}
+
+test_fleet_failure_is_tolerated_by_default
+test_fleet_failure_is_strict_when_requested
+test_fleet_install_failure_respects_tolerance_mode
+test_default_setup_keeps_combined_package_transaction
+test_combined_install_failure_respects_tolerance_mode
+test_full_setup_fleet_download_failure_respects_tolerance_mode
+test_fleet_only_skips_metrics_stack
+test_full_setup_retains_metrics_stack
+
+echo "PASS: setup-raw mode and Fleet failure handling"


### PR DESCRIPTION
## Summary

- Add `--fleet-only` to install the preconfigured Fleet package without InfluxDB, Telegraf, Grafana, hardware metadata collection, or metrics package repositories.
- Preserve the existing full metrics stack as the default setup mode.
- Keep Fleet failures tolerated by default while making download and package-install failures return nonzero with `--strict-failures`.

## Existing usage compatibility

- `setup.sh` is unchanged from `main` and continues forwarding all arguments to `setup-raw.sh`.
- A successful no-argument/default invocation retains the existing setup sequence.
- The default full-stack path retains one combined apt transaction containing Grafana, InfluxDB, Telegraf, and Fleet.
- The existing tolerant fallback still retries metrics packages without Fleet if the combined apt transaction fails.
- Behavior diverges only for the new `--fleet-only` mode and for strict Fleet failures, which now correctly return nonzero.

## Reconciler integration

- Supports CPU-only Strata guests that require Fleet enrollment but do not need the local GPU metrics stack.
- Companion reconciler MR: https://gitlab.com/nvidia/launchpad/laboratory/vmaas/reconciler/-/merge_requests/57

## Validation

- `bash -n setup.sh setup-raw.sh tests/test-setup-raw.sh`
- `tests/test-setup-raw.sh` with macOS Bash 3.2
- `docker run ... ubuntu:22.04 bash /repo/tests/test-setup-raw.sh`
- `docker run ... ubuntu:24.04 bash /repo/tests/test-setup-raw.sh`
- `git diff --check`
- Verified `setup.sh` is byte-identical to `main` by SHA-256.

## Merge

- Squash commits when merging.