### PR TITLE
Add ARM64 Fleet package installation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This setup handles sensitive AWS credentials and database passwords. The followi
 
 #### Default: Fast Raw Shell Setup
 For fresh instances where startup time matters, use `setup.sh`. It delegates to the flattened raw shell installer, leaves the Ansible playbook and roles in place, and skips Python, the Python virtualenv, and Ansible install work.
-When run from a checkout, `setup.sh` also uses local Grafana assets instead of fetching them over HTTP and installs the metrics packages plus the Fleet deb in a single apt transaction.
+When run from a checkout, `setup.sh` also uses local Grafana assets instead of fetching them over HTTP and installs the metrics packages plus the Fleet deb in a single apt transaction. The installer detects the Debian package architecture and selects the matching AMD64 or ARM64 Fleet package.
 
 ```bash
 curl -sSL https://raw.githubusercontent.com/Shiftius/ansible-gpu-metrics-collector/main/setup.sh | \
@@ -61,7 +61,7 @@ curl -sSL https://raw.githubusercontent.com/Shiftius/ansible-gpu-metrics-collect
 `setup-raw.sh` can still be invoked directly from a checkout or via curl when you do not need the compatibility wrapper.
 For compatibility with the former Ansible extra-vars flow, the raw installer accepts the existing setup values
 for `aws_timestream_*`, `environmentID`, `domain`, `host_prefix`, `skip_hostname_conf`, `influx.*`,
-`grafana.subpath`, `fleet_amd64_url`, `fleet_pkg_amd64`, `metadata_path`, and `metadata_backup`.
+`grafana.subpath`, `fleet_amd64_url`, `fleet_pkg_amd64`, `fleet_arm64_url`, `fleet_pkg_arm64`, `metadata_path`, and `metadata_backup`.
 
 #### Benchmarking Raw vs. Ansible Setup
 Use `reset-setup.sh` between runs to remove the metrics packages, generated config, repositories, local metrics data, and metadata created by either setup path.

--- a/reset-setup.sh
+++ b/reset-setup.sh
@@ -11,6 +11,7 @@ REFRESH_APT=false
 TOLERATE_FAILURES=true
 FLEET_PACKAGE_NAME="${FLEET_PACKAGE_NAME:-fleet-osquery}"
 FLEET_PKG_AMD64="${FLEET_PKG_AMD64:-fleet-1.0.0_amd64.deb}"
+FLEET_PKG_ARM64="${FLEET_PKG_ARM64:-fleet-1.0.0_arm64.deb}"
 METADATA_PATH="${METADATA_PATH:-/etc/brev/metadata.json}"
 TEMP_INFLUXDB_UNIT_CREATED=false
 TEMP_INFLUXDB_UNIT_PATH="/etc/systemd/system/influxdb.service"
@@ -284,7 +285,8 @@ remove_config_and_data() {
         /etc/grafana \
         /etc/influxdb \
         /etc/influxdb2 \
-        "/opt/${FLEET_PKG_AMD64}"
+        "/opt/${FLEET_PKG_AMD64}" \
+        "/opt/${FLEET_PKG_ARM64}"
 
     if [[ "$PURGE_DATA" == true ]]; then
         echo_info "Removing generated metrics data and metadata..."

--- a/roles/fleet_config/defaults/main.yml
+++ b/roles/fleet_config/defaults/main.yml
@@ -2,3 +2,5 @@
 # defaults file for fleet_config
 fleet_amd64_url: "https://github.com/Shiftius/ansible-gpu-metrics-collector/releases/download/pkg-1.0.0/f2a389a0c40047587c32daafd34d407bc130075f8d29decf2c0aad5f60464043"
 fleet_pkg_amd64: "fleet-1.0.0_amd64.deb"
+fleet_arm64_url: "https://github.com/Shiftius/ansible-gpu-metrics-collector/releases/download/pkg-1.0.0/80c7434e73e1c5dff018a8a8c21ed464446cb7d25170b5644ebef84805ac6edb"
+fleet_pkg_arm64: "fleet-1.0.0_arm64.deb"

--- a/roles/fleet_config/tasks/main.yml
+++ b/roles/fleet_config/tasks/main.yml
@@ -1,8 +1,21 @@
 ---
+- name: Validate Fleet package architecture
+  ansible.builtin.assert:
+    that:
+      - ansible_architecture in ["x86_64", "aarch64"]
+    fail_msg: "No Fleet package is configured for {{ ansible_architecture }}"
+  tags: packages
+
+- name: Select Fleet package
+  ansible.builtin.set_fact:
+    fleet_selected_url: "{{ fleet_arm64_url if ansible_architecture == 'aarch64' else fleet_amd64_url }}"
+    fleet_selected_pkg: "{{ fleet_pkg_arm64 if ansible_architecture == 'aarch64' else fleet_pkg_amd64 }}"
+  tags: packages
+
 - name: Download pkg
   get_url:
-    url: "{{ fleet_amd64_url }}"
-    dest: "/opt/{{ fleet_pkg_amd64 }}"
+    url: "{{ fleet_selected_url }}"
+    dest: "/opt/{{ fleet_selected_pkg }}"
     mode: "0644"
   tags: packages
   ignore_errors: true
@@ -10,8 +23,7 @@
 
 - name: Install pkg
   ansible.builtin.apt:
-    deb: "/opt/{{ fleet_pkg_amd64 }}"
+    deb: "/opt/{{ fleet_selected_pkg }}"
   tags: packages
   ignore_errors: true
   no_log: true
-

--- a/setup-raw.sh
+++ b/setup-raw.sh
@@ -13,6 +13,8 @@ export HISTFILE=/dev/null
 readonly DEFAULT_ASSET_BASE_URL="https://raw.githubusercontent.com/Shiftius/ansible-gpu-metrics-collector/main"
 readonly DEFAULT_FLEET_AMD64_URL="https://github.com/Shiftius/ansible-gpu-metrics-collector/releases/download/pkg-1.0.0/f2a389a0c40047587c32daafd34d407bc130075f8d29decf2c0aad5f60464043"
 readonly DEFAULT_FLEET_PKG_AMD64="fleet-1.0.0_amd64.deb"
+readonly DEFAULT_FLEET_ARM64_URL="https://github.com/Shiftius/ansible-gpu-metrics-collector/releases/download/pkg-1.0.0/80c7434e73e1c5dff018a8a8c21ed464446cb7d25170b5644ebef84805ac6edb"
+readonly DEFAULT_FLEET_PKG_ARM64="fleet-1.0.0_arm64.deb"
 
 SCRIPT_SOURCE="${BASH_SOURCE[0]:-}"
 SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_SOURCE")" >/dev/null 2>&1 && pwd || true)"
@@ -26,6 +28,10 @@ DOMAIN_VALUE="${DOMAIN:-${domain:-domain.com}}"
 ENVIRONMENT_ID_VALUE="${ENVIRONMENT_ID:-${environmentID:-}}"
 FLEET_AMD64_URL="${FLEET_AMD64_URL:-${fleet_amd64_url:-$DEFAULT_FLEET_AMD64_URL}}"
 FLEET_PKG_AMD64="${FLEET_PKG_AMD64:-${fleet_pkg_amd64:-$DEFAULT_FLEET_PKG_AMD64}}"
+FLEET_ARM64_URL="${FLEET_ARM64_URL:-${fleet_arm64_url:-$DEFAULT_FLEET_ARM64_URL}}"
+FLEET_PKG_ARM64="${FLEET_PKG_ARM64:-${fleet_pkg_arm64:-$DEFAULT_FLEET_PKG_ARM64}}"
+SELECTED_FLEET_URL=""
+SELECTED_FLEET_PKG=""
 GRAFANA_SUBPATH="${GRAFANA_SUBPATH:-metrics}"
 HOST_PREFIX="${HOST_PREFIX:-brev}"
 INFLUX_BUCKET="${INFLUX_BUCKET:-lp}"
@@ -369,6 +375,14 @@ parse_args() {
                 value="${arg#*=}"
                 FLEET_PKG_AMD64="$value"
                 ;;
+            fleet_arm64_url=*|FLEET_ARM64_URL=*)
+                value="${arg#*=}"
+                FLEET_ARM64_URL="$value"
+                ;;
+            fleet_pkg_arm64=*|FLEET_PKG_ARM64=*)
+                value="${arg#*=}"
+                FLEET_PKG_ARM64="$value"
+                ;;
             *)
                 echo_warn "Ignoring unsupported argument: ${arg%%=*}"
                 ;;
@@ -459,12 +473,49 @@ handle_fleet_install_failure() {
     return 1
 }
 
+detect_debian_architecture() {
+    if command -v dpkg >/dev/null 2>&1; then
+        dpkg --print-architecture
+        return
+    fi
+
+    printf 'unknown\n'
+}
+
+select_fleet_package() {
+    local architecture
+
+    architecture="$(detect_debian_architecture)"
+    case "$architecture" in
+        amd64)
+            SELECTED_FLEET_URL="$FLEET_AMD64_URL"
+            SELECTED_FLEET_PKG="$FLEET_PKG_AMD64"
+            ;;
+        arm64)
+            SELECTED_FLEET_URL="$FLEET_ARM64_URL"
+            SELECTED_FLEET_PKG="$FLEET_PKG_ARM64"
+            ;;
+        *)
+            echo_error "Unsupported Fleet package architecture: ${architecture}"
+            return 1
+            ;;
+    esac
+
+    echo_info "Using Fleet package for ${architecture}: ${SELECTED_FLEET_PKG}"
+}
+
 install_fleet_package() {
-    local pkg_path="/opt/${FLEET_PKG_AMD64}"
+    local pkg_path
 
     echo_info "Installing Fleet package..."
+    if ! select_fleet_package; then
+        handle_fleet_install_failure "Fleet package selection failed"
+        return
+    fi
+
+    pkg_path="/opt/${SELECTED_FLEET_PKG}"
     rm -f "$pkg_path"
-    if ! download_file "$FLEET_AMD64_URL" "$pkg_path" 0644; then
+    if ! download_file "$SELECTED_FLEET_URL" "$pkg_path" 0644; then
         handle_fleet_install_failure "Fleet package download failed"
         return
     fi
@@ -475,10 +526,21 @@ install_fleet_package() {
 }
 
 install_metrics_packages() {
-    local pkg_path="/opt/${FLEET_PKG_AMD64}"
+    local pkg_path
 
     echo_info "Installing metrics packages..."
-    if ! download_file "$FLEET_AMD64_URL" "$pkg_path" 0644; then
+    if ! select_fleet_package; then
+        if [[ "$TOLERATE_FAILURES" == false ]]; then
+            return 1
+        fi
+
+        echo_warn "Fleet package selection failed; installing metrics packages without Fleet."
+        apt_install grafana influxdb2 influxdb2-cli telegraf
+        return
+    fi
+
+    pkg_path="/opt/${SELECTED_FLEET_PKG}"
+    if ! download_file "$SELECTED_FLEET_URL" "$pkg_path" 0644; then
         if [[ "$TOLERATE_FAILURES" == false ]]; then
             echo_error "Fleet package download failed."
             return 1

--- a/tests/test-setup-raw.sh
+++ b/tests/test-setup-raw.sh
@@ -11,10 +11,60 @@ sed '/^parse_tolerance_flag "\$@"/,$d' "${repo_root}/setup-raw.sh" > "$library_c
 # shellcheck source=/dev/null
 source "$library_copy"
 FLEET_PKG_AMD64="../tmp/$(basename "$test_fleet_package")"
+detect_debian_architecture() { printf 'amd64\n'; }
 
 fail() {
     echo "FAIL: $*" >&2
     exit 1
+}
+
+test_fleet_package_selection() {
+    (
+        detect_debian_architecture() { printf 'amd64\n'; }
+        select_fleet_package
+        [[ "$SELECTED_FLEET_URL" == "$FLEET_AMD64_URL" ]] \
+            || fail "amd64 selected the wrong Fleet URL"
+        [[ "$SELECTED_FLEET_PKG" == "$FLEET_PKG_AMD64" ]] \
+            || fail "amd64 selected the wrong Fleet package"
+    )
+
+    (
+        detect_debian_architecture() { printf 'arm64\n'; }
+        select_fleet_package
+        [[ "$SELECTED_FLEET_URL" == "$FLEET_ARM64_URL" ]] \
+            || fail "arm64 selected the wrong Fleet URL"
+        [[ "$SELECTED_FLEET_PKG" == "$FLEET_PKG_ARM64" ]] \
+            || fail "arm64 selected the wrong Fleet package"
+    )
+
+    (
+        detect_debian_architecture() { printf 'riscv64\n'; }
+        if select_fleet_package; then
+            fail "unsupported architecture selected a Fleet package"
+        fi
+    )
+}
+
+test_arm64_install_uses_arm_package() {
+    local trace
+    local test_arm64_package
+    trace="$(mktemp)"
+    test_arm64_package="../tmp/$(basename "$test_fleet_package")"
+
+    (
+        detect_debian_architecture() { printf 'arm64\n'; }
+        FLEET_PKG_ARM64="$test_arm64_package"
+        download_file() { printf 'download %s %s %s\n' "$@" >> "$trace"; }
+        apt_install() { printf 'install %s\n' "$*" >> "$trace"; }
+
+        install_fleet_package
+    )
+
+    [[ "$(sed -n '1p' "$trace")" == "download ${FLEET_ARM64_URL} /opt/${test_arm64_package} 0644" ]] \
+        || fail "arm64 install used the wrong Fleet download"
+    [[ "$(sed -n '2p' "$trace")" == "install /opt/${test_arm64_package}" ]] \
+        || fail "arm64 install used the wrong Fleet package path"
+    rm -f "$trace"
 }
 
 test_fleet_failure_is_tolerated_by_default() {
@@ -191,6 +241,8 @@ test_full_setup_retains_metrics_stack() {
     rm -f "$trace"
 }
 
+test_fleet_package_selection
+test_arm64_install_uses_arm_package
 test_fleet_failure_is_tolerated_by_default
 test_fleet_failure_is_strict_when_requested
 test_fleet_install_failure_respects_tolerance_mode


### PR DESCRIPTION
## Summary

- Publish the Fleet `1.35.0` ARM64 deb alongside the existing AMD64 release asset.
- Detect `amd64` or `arm64` in the raw installer and select the matching Fleet package.
- Select `x86_64` or `aarch64` in the Ansible role and reject unsupported architectures.
- Remove either staged Fleet package during reset and document the ARM64 overrides.
- Add focused regression coverage for ARM64 selection, download, and apt installation routing.

## Package

- Release asset: https://github.com/Shiftius/ansible-gpu-metrics-collector/releases/download/pkg-1.0.0/80c7434e73e1c5dff018a8a8c21ed464446cb7d25170b5644ebef84805ac6edb
- SHA-256: `80c7434e73e1c5dff018a8a8c21ed464446cb7d25170b5644ebef84805ac6edb`
- Package metadata: `fleet-osquery` `1.35.0`, architecture `arm64`

## Validation

- `bash -n setup.sh setup-raw.sh setup-via-ansible.sh reset-setup.sh tests/test-setup-raw.sh`
- `bash tests/test-setup-raw.sh`
- `ANSIBLE_ROLES_PATH=$PWD/roles ansible-playbook --syntax-check roles/fleet_config/tests/test.yml -i roles/fleet_config/tests/inventory`
- Downloaded the public GitHub asset and verified its SHA-256 and Debian control metadata.

## Security note

- The Fleet-generated package contains `ORBIT_FLEET_URL` and `ORBIT_ENROLL_SECRET`, matching the existing AMD64 packaging model.
- Because this repository and release are public, third parties can obtain the enrollment configuration and potentially enroll hosts into the configured Fleet deployment.
- Consider rotating the enrollment secret and moving to a generic package plus separately delivered enrollment configuration if public consumers should not be trusted.

## Merge

- Squash this single commit when the draft is approved.